### PR TITLE
Pull Request用のGitHub Actions CIをローカル固定環境へ揃える

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: setup
-        run: cp .env.example src/.env
-
-      - name: cache vendor
-        id: cache
+      - name: cache composer vendor
         uses: actions/cache@v4
         with:
           path: ./src/vendor
@@ -30,31 +26,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: composer install
-        if: steps.cache.outputs.cache-hit != 'true'
+      # ローカルと同じ固定PHP・Composer・MySQLで、依存関係導入・DB起動・
+      # Laravelのbootstrap確認・テスト実行までを Issue #210 の `make check` に委ねる。
+      # composer:latest は使用しない。
+      - name: make check
+        run: make check
+
+      - name: generate junit report
+        if: ${{ github.event_name == 'push' }}
+        run: docker compose exec -T --env XDEBUG_MODE=off web php artisan test --log-junit result.xml
+
+      - name: build html test report
+        if: ${{ github.event_name == 'push' }}
         run: |
-          cd src
-          docker run --rm --interactive --volume "$PWD:/app" composer install
-          cd ..
-
-      - name: docker start
-        run: docker compose up --build -d web db
-
-      - name: wait start db
-        run: docker compose up --build db-check
-
-      - name: test data insert
-        run: docker compose exec -T web php artisan db:seed
-
-      - name: test
-        run: |
-          docker compose exec -T web php artisan test --log-junit result.xml
-          curl -o lib/phpunit.xslt https://gist.githubusercontent.com/jrfnl/3c28ea6d9b07fd48656d/raw/aaeb0b879647b1cf1dbfd461a2c4a8e292be738d/phpunit.xslt
-          mkdir report
+          curl -fsSL -o lib/phpunit.xslt https://gist.githubusercontent.com/jrfnl/3c28ea6d9b07fd48656d/raw/aaeb0b879647b1cf1dbfd461a2c4a8e292be738d/phpunit.xslt
+          mkdir -p report
           php lib/convert_html.php
-
-      - name: Docker stop
-        run: docker compose stop
 
       - name: store test report
         if: ${{ github.event_name == 'push' }}
@@ -62,6 +49,10 @@ jobs:
         with:
           name: test-report
           path: report
+
+      - name: cleanup containers
+        if: ${{ always() }}
+        run: docker compose down --volumes --remove-orphans
 
   publish-test-report:
     if: ${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ make check
 
 ## テスト
 
-mainにプッシュするとGitHub Actionsによって[GitHub Pages](https://bvlion.github.io/holidays-webhook-server/index.html)にテスト結果がアップされる。GitHub ActionsのPHP・Composer環境固定はIssue #211で扱う。
+Pull Requestの作成・更新、mainへのpush、Dependabotが作成するPull Requestでは、GitHub Actionsがローカルと同じ固定PHP 8.2.30・Composer 2.8.12・MySQL 5.7.35で `make check` を実行する。mainにプッシュした場合だけ、テスト結果を[GitHub Pages](https://bvlion.github.io/holidays-webhook-server/index.html)へアップし、Slackへ通知する。

--- a/docs/current-operations.md
+++ b/docs/current-operations.md
@@ -88,16 +88,12 @@ Featureテストはデータベース時刻を取得するため、実行時にM
 Dependabotを含めて通常のpull requestを使い、Pull RequestのコードをSecretへアクセスできる `pull_request_target` では実行しない。処理内容は次のとおりである。
 
 1. 対象コミットをチェックアウトする。
-2. ルートの `.env.example` を `src/.env` へコピーする。
-3. Composer依存関係をキャッシュし、未取得時はComposerコンテナでインストールする。
-4. `web` と `db` をビルドして起動する。
-5. `db-check` でMySQLの起動を待つ。
-6. データベースシーダーを実行する。
-7. PHPUnitを実行してJUnit XMLを作る。
-8. 外部URLからXSLTをダウンロードし、HTMLレポートへ変換する。
-9. Docker Composeサービスを停止する。
-10. mainへのpushでは、テストレポートをartifactで公開jobへ渡し、`gh-pages` ブランチへ配置する。
-11. mainへのpushでは、テストとレポート公開の結果をSlackへ通知する。
+2. `src/composer.lock` のハッシュを鍵として `src/vendor` をキャッシュする。
+3. `make check` を実行する。ローカルの `make check` と同じ手順で、`.env.example` から `src/.env` を作成し、Webイメージ内の固定PHP 8.2.30・Composer 2.8.12で依存関係を導入し、`db` と `db-check` でMySQL 5.7.35の起動を待ち、データベースシーダーを実行し、PHP・Composerのバージョンと必要拡張を確認し、PHPUnitを実行する。`composer:latest` などの固定外イメージは使用しない。
+4. mainへのpushでは、追加でJUnit XMLを出力するPHPUnit実行、外部URLからのXSLTダウンロード、HTMLレポートへの変換を行う。
+5. 成否にかかわらず、`docker compose down --volumes --remove-orphans` でコンテナ・ネットワーク・ボリュームを後処理する。
+6. mainへのpushでは、テストレポートをartifactで公開jobへ渡し、`gh-pages` ブランチへ配置する。
+7. mainへのpushでは、テストとレポート公開の結果をSlackへ通知する。
 
 Pull Requestで実行するテストjobはリポジトリ内容の読み取り権限だけを持ち、Secretを使用しない。`gh-pages` への書き込み権限はmainへのpushでだけ実行する公開jobに限定する。
 


### PR DESCRIPTION
## 目的

Issue #211 の対応。Pull Requestの依存関係導入とLaravelアプリケーションの基本検証をGitHub Actionsで自動実行し、CIとローカルの検証手順を一致させる。

## 事前確認（Issue #208〜#210）

- `docs/current-architecture.md` / `docs/current-operations.md`（Issue #208）: ローカルはPHP 8.2.30 + Apache、MySQL Server 5.7.35。Laravelマイグレーションは存在せず、`docker/db/sql/*.sql` をMySQL初回起動時に適用する構成。
- `docs/secrets-management.md`（Issue #209）: CIは`.env.example`だけで起動し、Google・Slack・SSHの秘密情報を必要としない。テストjobはSecretsを使わず`contents: read`のみで実行する方針。Git履歴上の`APP_KEY`照合・本番キー変更は運用者作業であり、本PRの対象外（変更していない）。
- `.env.example` / `Makefile` / `docker-compose.yml`（Issue #210）: `make setup`・`make check`が、ローカル接続先ガード→Dockerイメージビルド→固定Composer(2.8.12)でのインストール→`web`/`db`起動→`db-check`によるMySQL応答待ち→PHP/Composerバージョンと拡張確認→`composer check-platform-reqs`→`php artisan test`までを1コマンドで実行する。`docker/web/Dockerfile`はPHP 8.2.30-apache + Composer 2.8.12を固定イメージとしてビルドする。

## 変更内容

`.github/workflows/test.yaml` を、`composer:latest`イメージを直接使う独自実装から、Issue #210で整備したローカル検証手順（`make check`）をそのまま呼び出す構成に変更した。

- `composer install`をComposerの`composer:latest`公式イメージ経由で実行していた箇所を削除し、`make check`に一本化。`make check`は`docker/web/Dockerfile`が固定するPHP 8.2.30 + Composer 2.8.12のコンテナ内で`composer install --no-interaction --prefer-dist`を実行するため、ローカルとCIのPHP・Composerが一致する。
- `make check`内で`db`・`db-check`（MySQL 5.7.35の起動待ち）→ DBシーダー実行 → PHP/Composerバージョン確認 → 必要拡張確認 → `composer check-platform-reqs --no-dev` → `php artisan test`まで一括実行するため、CIの主要な検証入口をローカルと一致させた。
- `src/vendor`のキャッシュは`src/composer.lock`のハッシュを鍵に従来どおり利用（`actions/cache@v4`）。キャッシュヒット時も`composer install`自体は実行されるが、Composerの差分検出により実質的に高速化される。
- `.env.example`からの`src/.env`生成は`make check`が内部の`environment`ターゲットで行うため、ワークフロー側の`cp`ステップを削除した。外部の秘密情報は使用しない。
- テスト用JUnitレポート生成・HTMLレポート変換・GitHub Pagesへの公開・Slack通知は、従来どおり`github.event_name == 'push'`（mainへのpush）でのみ実行する構成を維持。テストjob自体はSecretsを参照せず、権限も`permissions: contents: read`のまま変更していない。
- 成否にかかわらずコンテナ・ネットワーク・ボリュームを後処理するため、`docker compose stop`を`if: always()`付きの`docker compose down --volumes --remove-orphans`に変更（従来はテスト失敗時にこのステップがスキップされ、コンテナが残る問題があった）。
- トリガー（`pull_request`イベント、`pull_request_target`不使用、`main`へのpush）は変更していない。標準の`pull_request`イベントのため、DependabotのPull Requestでも秘密情報なしで同じジョブが実行される。
- 実態と一致するよう、README.mdと`docs/current-operations.md`のCI関連の記述を更新した（Issue #211への転送参照を削除し、実際の`make check`ベースの構成を記載）。

## このPRで行っていないこと

- PHP 8.5への更新
- LaravelやComposer依存関係のアップグレード
- Dependabotの自動マージ有効化
- 本番デプロイ構成（`.github/workflows/deploy.yaml`）の変更
- Issue #209で残っている本番`APP_KEY`の照合・変更

## 検証（実行コマンドと結果）

- `actionlint .github/workflows/test.yaml` → 指摘なし（`exit=0`）。参考として`deploy.yaml`も実行したが、本PR対象外の既存指摘（`actions/checkout@v2`・`actions/cache@v1`の更新推奨、SC2086）のみで、`test.yaml`には指摘なし。
- `git diff --check` → 指摘なし（`exit=0`、空白関連の混入なし）。
- ローカルの`hw_web`/`hw_db`はこのマシン上で稼働中の個人開発用コンテナであり、`src/.env`もローカル固定値（`DB_HOST=db`等）とは異なる個人設定になっていたため、`local-environment-guard`は意図どおりこの設定を拒否する。誤って稼働中の開発環境を壊さないよう、共有ローカル環境上では`make check`を実行せず、本Pull Request自体のGitHub Actions実行を実環境での検証とした（結果は下記）。
- 本PR（GitHub Actions run [30878786064](https://github.com/bvlion/holidays-webhook-server/actions/runs/30878786064)、`pull_request`イベント）で`make check`が成功したことを確認した。ログで次を確認済み。
  - `PHP 8.2.30 (cli)` / `Composer version 2.8.12` （ローカル固定版と一致）
  - `db-check`が`mysql/mysql-server:5.7.35`イメージをビルドして起動確認（ローカル固定版と一致）
  - `composer install --no-interaction --prefer-dist`が固定Web環境コンテナ内で実行され、`composer:latest`や外部Composerコンテナは使用していない
  - 拡張確認（`pdo_mysql`, `intl`, `gd`, `zip`）と`composer check-platform-reqs --no-dev`が成功
  - `php artisan test` → `Tests: 2 passed`（現行テスト2件が成功、DB接続を伴うFeatureテストを含む＝Laravelのbootstapとデータベース接続を確認）
  - `docker compose down --volumes --remove-orphans`がジョブ末尾で実行され、コンテナ・ネットワーク・ボリュームを後処理

### 完了条件チェック

- [x] 通常のPull RequestでCIが成功する（本PRのrun 30878786064で確認）
- [x] `main`へのpushでもCIが成功する構成（トリガーは変更なし、同一jobを使用）
- [x] DependabotのPull Requestでも秘密情報なしで実行できる（`pull_request`イベント・Secrets未参照・`.env.example`のみで構成、変更なし）
- [x] CI上のPHP、Composer、MySQLがローカルの固定バージョンと一致（PHP 8.2.30 / Composer 2.8.12 / MySQL 5.7.35をログで確認）
- [x] `make check`とCIの検証内容が一致（CIの主要な検証入口を`make check`に統一）
- [x] `composer:latest`起因の失敗が解消（`composer:latest`イメージの直接使用を削除）
- [x] `actionlint` 指摘なし
- [x] `git diff --check` 指摘なし

Closes #211

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>