### PR TITLE
主要ユースケースの回帰テストを追加する

### DIFF
--- a/src/app/Console/Commands/TimeTrigger.php
+++ b/src/app/Console/Commands/TimeTrigger.php
@@ -116,7 +116,7 @@ class TimeTrigger extends Command
       return;
     }
 
-    $client = new Client();
+    $client = app(Client::class);
 
     $requests = function() use ($client, $triggers) {
       foreach ($triggers as $trigger) {

--- a/src/app/Http/Controllers/Api/CommandExecController.php
+++ b/src/app/Http/Controllers/Api/CommandExecController.php
@@ -58,7 +58,7 @@ class CommandExecController extends BaseApiController
     $results = [];
 
     foreach ($commands as $command) {
-      $client = new Client();
+      $client = app(Client::class);
 
       $options = [];
       $options['allow_redirects'] = true;

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class User extends Model
+class User extends Model implements AuthenticatableContract
 {
-    use HasFactory;
+    use Authenticatable, HasFactory;
 
     protected $guarded = ['id'];
 

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -15,6 +16,11 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton('HolidayList', function() {
             return new \App\Libs\HolidayList();
+        });
+
+        // コンテナ経由で解決することで、テストからモック済みハンドラを注入できるようにする。
+        $this->app->singleton(Client::class, function() {
+            return new Client();
         });
     }
 

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -19,7 +19,9 @@ class AppServiceProvider extends ServiceProvider
         });
 
         // コンテナ経由で解決することで、テストからモック済みハンドラを注入できるようにする。
-        $this->app->singleton(Client::class, function() {
+        // singleton にすると従来コマンドごとに new Client() していた生成単位が変わってしまうため、
+        // 解決のたびに新しいインスタンスを返す bind を使う。
+        $this->app->bind(Client::class, function() {
             return new Client();
         });
     }

--- a/src/database/factories/CalenderFactory.php
+++ b/src/database/factories/CalenderFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Calender;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CalenderFactory extends Factory
+{
+    protected $model = Calender::class;
+
+    public function definition()
+    {
+        return [
+            'target_name' => 'API SET',
+            'target_id' => 1,
+            'target_type' => 'user',
+            'target_date' => $this->faker->date(),
+            'is_holiday' => 0,
+        ];
+    }
+}

--- a/src/database/factories/CommandFactory.php
+++ b/src/database/factories/CommandFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Command;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CommandFactory extends Factory
+{
+    protected $model = Command::class;
+
+    public function definition()
+    {
+        return [
+            'target_name' => $this->faker->word,
+            'target_id' => 1,
+            'target_type' => 'user',
+            'url' => $this->faker->url,
+            'method' => 'GET',
+            'body_type' => 'json',
+            'headers' => '',
+            'parameters' => '',
+        ];
+    }
+}

--- a/src/database/factories/ExecResultFactory.php
+++ b/src/database/factories/ExecResultFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ExecResult;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ExecResultFactory extends Factory
+{
+    protected $model = ExecResult::class;
+
+    public function definition()
+    {
+        return [
+            'command_id' => 1,
+            'trigger_id' => 1,
+            'exec_time' => $this->faker->dateTime()->format('Y-m-d H:i:s'),
+            'response_code' => 200,
+            'response_header' => '{}',
+            'response_body' => '',
+        ];
+    }
+}

--- a/src/database/factories/GroupFactory.php
+++ b/src/database/factories/GroupFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GroupFactory extends Factory
+{
+    protected $model = Group::class;
+
+    public function definition()
+    {
+        return [
+            'token' => $this->faker->unique()->sha256,
+            'email' => $this->faker->unique()->safeEmail,
+            'premium' => 0,
+        ];
+    }
+}

--- a/src/database/factories/OnetimeSkipFactory.php
+++ b/src/database/factories/OnetimeSkipFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\OnetimeSkip;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class OnetimeSkipFactory extends Factory
+{
+    protected $model = OnetimeSkip::class;
+
+    public function definition()
+    {
+        return [
+            'target_id' => 1,
+            'target_type' => 'time',
+        ];
+    }
+}

--- a/src/database/factories/SummarizeCommandFactory.php
+++ b/src/database/factories/SummarizeCommandFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SummarizeCommand;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SummarizeCommandFactory extends Factory
+{
+    protected $model = SummarizeCommand::class;
+
+    public function definition()
+    {
+        return [
+            'target_name' => $this->faker->word,
+            'target_id' => 1,
+            'target_type' => 'user',
+            'commands' => json_encode([]),
+        ];
+    }
+}

--- a/src/database/factories/TimeTriggerFactory.php
+++ b/src/database/factories/TimeTriggerFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TimeTrigger;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TimeTriggerFactory extends Factory
+{
+    protected $model = TimeTrigger::class;
+
+    public function definition()
+    {
+        return [
+            'target_name' => $this->faker->word,
+            'target_id' => 1,
+            'target_type' => 'user',
+            'time_from' => '00:00:00',
+            'time_to' => '23:59:00',
+            'exec_interval' => 1,
+            'target_week' => json_encode([1, 2, 3, 4, 5, 6, 7]),
+            'holiday_decision' => 'not_check',
+            'command_id' => 0,
+            'exec_notify' => 0,
+            'timezone' => '+09:00',
+            'country_code' => 'jp',
+            'exec_flag' => 1,
+        ];
+    }
+}

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition()
+    {
+        return [
+            'groups_id' => Group::factory(),
+            'api_token' => Str::random(60),
+            'user_name' => $this->faker->name,
+            'country_code' => 'jp',
+            'owner_flag' => 1,
+        ];
+    }
+}

--- a/src/tests/Doubles/FakeHolidayList.php
+++ b/src/tests/Doubles/FakeHolidayList.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Doubles;
+
+/**
+ * app()->make('HolidayList') はダミー文字列キーで解決される (App\Providers\AppServiceProvider参照)。
+ * 型宣言のない呼び出し規約に合わせたテスト用の差し替えで、実際のGoogle Calendar APIへは通信しない。
+ */
+class FakeHolidayList
+{
+    /** @var array<string, array<string, string>> */
+    private $holidaysByKey;
+
+    /** @var string[] */
+    public $requestedKeys = [];
+
+    /** @var int */
+    public $clearedCalls = 0;
+
+    public function __construct(array $holidaysByKey = [])
+    {
+        $this->holidaysByKey = $holidaysByKey;
+    }
+
+    public function getHolidays($code, $year)
+    {
+        $key = $code . $year;
+        $this->requestedKeys[] = $key;
+
+        return $this->holidaysByKey[$key] ?? [];
+    }
+
+    public function clear()
+    {
+        $this->clearedCalls++;
+
+        return [];
+    }
+}

--- a/src/tests/Feature/Api/ApiAuthenticationTest.php
+++ b/src/tests/Feature/Api/ApiAuthenticationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ApiAuthenticationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_未認証の場合はAPIへアクセスできない()
+    {
+        $response = $this->getJson('/api/commands');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_有効なAPIトークンで認証済みの場合はAPIへアクセスできる()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/commands');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_APIトークンをクエリパラメータで渡しても認証できる()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->getJson('/api/commands?api_token=' . $user->api_token);
+
+        $response->assertStatus(200);
+    }
+}

--- a/src/tests/Feature/Api/CalendarControllerTest.php
+++ b/src/tests/Feature/Api/CalendarControllerTest.php
@@ -121,11 +121,13 @@ class CalendarControllerTest extends TestCase
     {
         $user = User::factory()->create();
 
+        // Eloquentモデルを直接returnした場合、Laravelは wasRecentlyCreated を見て
+        // 新規作成時のみ自動的に201を返す(更新時は200)。
         $this->actingAs($user, 'api')->postJson('/api/calendar/upsert', [
             'type' => 'user',
             'date' => '2026-05-05',
             'holiday' => 1,
-        ])->assertStatus(200);
+        ])->assertStatus(201);
 
         $this->actingAs($user, 'api')->postJson('/api/calendar/upsert', [
             'type' => 'user',

--- a/src/tests/Feature/Api/CalendarControllerTest.php
+++ b/src/tests/Feature/Api/CalendarControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Calender;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\Doubles\FakeHolidayList;
+use Tests\TestCase;
+
+class CalendarControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function fakeHolidays(array $holidaysByKey)
+    {
+        $fake = new FakeHolidayList($holidaysByKey);
+        $this->app->instance('HolidayList', $fake);
+
+        return $fake;
+    }
+
+    public function test_Google_Calendarの祝日のみ存在する場合はholidayがtrueでforceはfalse()
+    {
+        $this->fakeHolidays(['jp2026' => ['2026-01-01' => '元日']]);
+        $user = User::factory()->create(['country_code' => 'jp']);
+
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/calendar/holiday?type=user&date=2026-01-01');
+
+        $response->assertStatus(200)->assertExactJson(['holiday' => true, 'force' => false]);
+    }
+
+    public function test_Google_Calendarが休日でなくても個人カレンダーの祝日設定が優先される()
+    {
+        $this->fakeHolidays(['jp2026' => []]);
+        $user = User::factory()->create(['country_code' => 'jp']);
+        Calender::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_date' => '2026-01-02',
+            'is_holiday' => 1,
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/calendar/holiday?type=user&date=2026-01-02');
+
+        $response->assertStatus(200)->assertExactJson(['holiday' => true, 'force' => true]);
+    }
+
+    public function test_Google_Calendarが休日でも個人カレンダーの非祝日設定が優先される()
+    {
+        $this->fakeHolidays(['jp2026' => ['2026-01-01' => '元日']]);
+        $user = User::factory()->create(['country_code' => 'jp']);
+        Calender::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_date' => '2026-01-01',
+            'is_holiday' => 0,
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/calendar/holiday?type=user&date=2026-01-01');
+
+        $response->assertStatus(200)->assertExactJson(['holiday' => false, 'force' => true]);
+    }
+
+    public function test_typeがgroupの場合は同じグループの別ユーザーでも上書き結果を共有する()
+    {
+        $this->fakeHolidays(['jp2026' => []]);
+        $group = Group::factory()->create();
+        $ownerUser = User::factory()->create(['groups_id' => $group->id, 'country_code' => 'jp']);
+        $memberUser = User::factory()->create(['groups_id' => $group->id, 'country_code' => 'jp', 'owner_flag' => 0]);
+        Calender::factory()->create([
+            'target_id' => $group->id,
+            'target_type' => 'group',
+            'target_date' => '2026-03-03',
+            'is_holiday' => 1,
+        ]);
+
+        $response = $this->actingAs($memberUser, 'api')
+            ->getJson('/api/calendar/holiday?type=group&date=2026-03-03');
+
+        $response->assertStatus(200)->assertExactJson(['holiday' => true, 'force' => true]);
+    }
+
+    public function test_typeまたはdateが無い場合は404を返す()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/calendar/holiday?type=user');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_不正な日付文字列は例外にならず1970年として扱われる()
+    {
+        $this->fakeHolidays([]);
+        $user = User::factory()->create(['country_code' => 'jp']);
+
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/calendar/holiday?type=user&date=not-a-date');
+
+        $response->assertStatus(200)->assertExactJson(['holiday' => false, 'force' => false]);
+    }
+
+    public function test_country_codeパラメータを指定するとユーザーの既定国コードより優先される()
+    {
+        $fake = $this->fakeHolidays(['us2026' => ['2026-07-04' => 'Independence Day']]);
+        $user = User::factory()->create(['country_code' => 'jp']);
+
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/calendar/holiday?type=user&date=2026-07-04&country_code=us');
+
+        $response->assertStatus(200)->assertExactJson(['holiday' => true, 'force' => false]);
+        $this->assertContains('us2026', $fake->requestedKeys);
+    }
+
+    public function test_upsertで同じ対象日に登録すると更新されて重複作成されない()
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'api')->postJson('/api/calendar/upsert', [
+            'type' => 'user',
+            'date' => '2026-05-05',
+            'holiday' => 1,
+        ])->assertStatus(200);
+
+        $this->actingAs($user, 'api')->postJson('/api/calendar/upsert', [
+            'type' => 'user',
+            'date' => '2026-05-05',
+            'holiday' => 0,
+        ])->assertStatus(200);
+
+        $this->assertSame(1, Calender::where('target_id', $user->id)
+            ->where('target_type', 'user')
+            ->where('target_date', '2026-05-05')
+            ->count());
+        $this->assertSame(0, Calender::where('target_id', $user->id)
+            ->where('target_type', 'user')
+            ->where('target_date', '2026-05-05')
+            ->first()->is_holiday);
+    }
+}

--- a/src/tests/Feature/Api/CommandExecControllerTest.php
+++ b/src/tests/Feature/Api/CommandExecControllerTest.php
@@ -18,6 +18,17 @@ class CommandExecControllerTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 既定では応答を持たない MockHandler を登録する。認可や404判定が回帰して
+        // 実際にHTTPリクエストを送る経路へ入った場合でも、外部ネットワークへは
+        // 接続せずキューが空のまま例外になりテストが失敗する。個別の応答が必要な
+        // テストは bindMockClient() で明示的に上書きする。
+        $this->bindMockClient([]);
+    }
+
     /**
      * @param array $responses GuzzleHttp\Psr7\Response または \Throwable の配列
      */

--- a/src/tests/Feature/Api/CommandExecControllerTest.php
+++ b/src/tests/Feature/Api/CommandExecControllerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Command;
+use App\Models\SummarizeCommand;
+use App\Models\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class CommandExecControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * @param array $responses GuzzleHttp\Psr7\Response または \Throwable の配列
+     */
+    private function bindMockClient(array $responses): void
+    {
+        $mock = new MockHandler($responses);
+        $handlerStack = HandlerStack::create($mock);
+        $this->app->instance(Client::class, new Client(['handler' => $handlerStack]));
+    }
+
+    public function test_自分が所有するコマンドを実行できる()
+    {
+        $this->bindMockClient([new Response(200, [], 'ok-body')]);
+        $user = User::factory()->create();
+        $command = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_name' => '実行対象コマンド',
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/' . $command->id);
+
+        $response->assertStatus(200);
+        $body = $response->json();
+        $this->assertSame('実行対象コマンド', $body[0]['name']);
+        $this->assertSame(200, $body[0]['response_code']);
+        // saveResult() は PSR-7 の StreamInterface をそのまま配列に詰めているため、
+        // json_encode() では本文が空オブジェクトへ変換される(公開プロパティを持たないため)。
+        // 実際のレスポンス本文はAPI応答へ反映されない、という現行の仕様を保護する。
+        $this->assertSame([], $body[0]['response_body']);
+    }
+
+    public function test_他人が所有するコマンドは実行できず403になる()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $command = Command::factory()->create([
+            'target_id' => $owner->id,
+            'target_type' => 'user',
+        ]);
+
+        $response = $this->actingAs($other, 'api')
+            ->postJson('/api/exec/command/' . $command->id);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_削除済みコマンドの実行は404になる()
+    {
+        $user = User::factory()->create();
+        $command = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'deleted_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/' . $command->id);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_存在しないコマンドの実行は404になる()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/999999');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_まとめ実行で複数コマンドの結果がまとめて返る()
+    {
+        $this->bindMockClient([
+            new Response(200, [], 'first'),
+            new Response(200, [], 'second'),
+        ]);
+        $user = User::factory()->create();
+        $commandA = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_name' => 'コマンドA',
+        ]);
+        $commandB = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_name' => 'コマンドB',
+        ]);
+        $summary = SummarizeCommand::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'commands' => json_encode([$commandA->id, $commandB->id]),
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/summary/' . $summary->id);
+
+        $response->assertStatus(200);
+        $results = $response->json();
+        $this->assertCount(2, $results);
+        $names = collect($results)->pluck('name')->all();
+        $this->assertEqualsCanonicalizing(['コマンドA', 'コマンドB'], $names);
+        $this->assertTrue(collect($results)->every(fn ($r) => $r['response_code'] === 200));
+    }
+
+    public function test_まとめ実行はまとめコマンド自体の所有権だけを確認し内包コマンドの所有権は確認しない()
+    {
+        // Issue #212 / docs/current-architecture.md 10.2 に記載された現行仕様をそのまま保護する回帰テスト。
+        $this->bindMockClient([new Response(200, [], 'other-owner-body')]);
+        $owner = User::factory()->create();
+        $otherOwner = User::factory()->create();
+        $commandOfOther = Command::factory()->create([
+            'target_id' => $otherOwner->id,
+            'target_type' => 'user',
+            'target_name' => '他人のコマンド',
+        ]);
+        $summary = SummarizeCommand::factory()->create([
+            'target_id' => $owner->id,
+            'target_type' => 'user',
+            'commands' => json_encode([$commandOfOther->id]),
+        ]);
+
+        $response = $this->actingAs($owner, 'api')
+            ->postJson('/api/exec/summary/' . $summary->id);
+
+        $response->assertStatus(200);
+        $this->assertSame('他人のコマンド', $response->json()[0]['name']);
+        $this->assertSame(200, $response->json()[0]['response_code']);
+    }
+
+    public function test_外部HTTPがエラー応答を返した場合はそのステータスが結果へ反映される()
+    {
+        // Guzzleのhttp_errorsミドルウェアが4xx/5xx応答を例外化するため、
+        // 実際のHTTPエラー応答と同じ経路で ServerException (RequestExceptionのサブクラス) が送出される。
+        $this->bindMockClient([new Response(500, [], 'server-error-body')]);
+        $user = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/' . $command->id);
+
+        $response->assertStatus(200);
+        $body = $response->json()[0];
+        $this->assertSame(500, $body['response_code']);
+    }
+
+    public function test_レスポンスを伴わないRequestExceptionは現状TypeErrorになる()
+    {
+        // 保存処理は必ずレスポンスオブジェクトを受け取る前提だが、
+        // RequestException::getResponse() は null を返し得るため現状は例外になる
+        // (docs/current-architecture.md 10.4)。修正はこのIssueの対象外であり、
+        // 現行仕様を保護する回帰テストとして記録する。
+        $this->bindMockClient([
+            new RequestException('connection failed', new Psr7Request('GET', 'http://example.test')),
+        ]);
+        $user = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+
+        $this->withoutExceptionHandling();
+        $this->expectException(\TypeError::class);
+
+        $this->actingAs($user, 'api')->postJson('/api/exec/command/' . $command->id);
+    }
+}

--- a/src/tests/Feature/Api/CommandsControllerTest.php
+++ b/src/tests/Feature/Api/CommandsControllerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Command;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class CommandsControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_一覧はユーザー自身と所属グループのコマンドを返す()
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['groups_id' => $group->id]);
+        $ownCommand = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+        $groupCommand = Command::factory()->create(['target_id' => $group->id, 'target_type' => 'group']);
+        $otherUsersCommand = Command::factory()->create(['target_id' => $user->id + 1000, 'target_type' => 'user']);
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/commands');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json())->pluck('id')->all();
+        $this->assertContains($ownCommand->id, $ids);
+        $this->assertContains($groupCommand->id, $ids);
+        $this->assertNotContains($otherUsersCommand->id, $ids);
+    }
+
+    public function test_ユーザー対象の削除済みコマンドは一覧の絞り込み条件をすり抜けて表示される()
+    {
+        // docs/current-architecture.md 10.3 に記載された現行クエリの仕様（バグ）を保護する回帰テスト。
+        // whereNull('deleted_at') が SQL 上 OR の右辺(グループ条件)にしか掛からないため、
+        // ユーザー対象は削除済みでも一覧に残る。
+        $user = User::factory()->create();
+        $deletedUserCommand = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'deleted_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/commands');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json())->pluck('id')->all();
+        $this->assertContains($deletedUserCommand->id, $ids);
+    }
+
+    public function test_グループ対象の削除済みコマンドは一覧から除外される()
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['groups_id' => $group->id]);
+        $deletedGroupCommand = Command::factory()->create([
+            'target_id' => $group->id,
+            'target_type' => 'group',
+            'deleted_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/commands');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json())->pluck('id')->all();
+        $this->assertNotContains($deletedGroupCommand->id, $ids);
+    }
+
+    public function test_必須項目が無い場合は登録時に400を返す()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/commands', [
+            'target_type' => 'user',
+        ]);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_target_typeがuserの場合は自分のIDが対象になる()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/commands', [
+            'target_name' => 'テストコマンド',
+            'target_type' => 'user',
+            'url' => 'https://example.test/webhook',
+            'method' => 'GET',
+            'body_type' => 'json',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHasCommand($user->id, 'user', 'テストコマンド');
+    }
+
+    public function test_target_typeがgroupの場合は所属グループのIDが対象になる()
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['groups_id' => $group->id]);
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/commands', [
+            'target_name' => 'グループコマンド',
+            'target_type' => 'group',
+            'url' => 'https://example.test/webhook',
+            'method' => 'POST',
+            'body_type' => 'form_params',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHasCommand($group->id, 'group', 'グループコマンド');
+    }
+
+    public function test_所有者は自分のコマンドを部分更新できる()
+    {
+        $user = User::factory()->create();
+        $command = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_name' => '旧名称',
+            'url' => 'https://example.test/old',
+        ]);
+
+        $response = $this->actingAs($user, 'api')->putJson('/api/commands/' . $command->id, [
+            'target_name' => '新名称',
+        ]);
+
+        $response->assertStatus(200);
+        $command->refresh();
+        $this->assertSame('新名称', $command->target_name);
+        $this->assertSame('https://example.test/old', $command->url);
+    }
+
+    public function test_他人のコマンドは更新できず403になる()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $owner->id, 'target_type' => 'user']);
+
+        $response = $this->actingAs($other, 'api')->putJson('/api/commands/' . $command->id, [
+            'target_name' => '書き換え',
+        ]);
+
+        $response->assertStatus(403);
+        $command->refresh();
+        $this->assertNotSame('書き換え', $command->target_name);
+    }
+
+    public function test_存在しないコマンドの更新は現状エラーになる()
+    {
+        // docs/current-architecture.md 10.2:
+        // 「存在しないコマンドまたはトリガーに対し...更新、削除...は取得結果を参照して500エラーになり得る」
+        // find() が null を返した後 null のプロパティを読むため、警告が例外化されて処理が止まる。
+        // 修正はこのIssueの対象外であり、現行仕様を保護する回帰テストとして記録する。
+        $user = User::factory()->create();
+
+        $this->withoutExceptionHandling();
+        $this->expectException(\ErrorException::class);
+
+        $this->actingAs($user, 'api')->putJson('/api/commands/999999', [
+            'target_name' => '書き換え',
+        ]);
+    }
+
+    public function test_所有者は自分のコマンドを削除でき論理削除される()
+    {
+        $user = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+
+        $response = $this->actingAs($user, 'api')->deleteJson('/api/commands/' . $command->id);
+
+        $response->assertStatus(200);
+        $this->assertNotNull($command->fresh()->deleted_at);
+    }
+
+    public function test_他人のコマンドは削除できず403になる()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $owner->id, 'target_type' => 'user']);
+
+        $response = $this->actingAs($other, 'api')->deleteJson('/api/commands/' . $command->id);
+
+        $response->assertStatus(403);
+        $this->assertNull($command->fresh()->deleted_at);
+    }
+
+    private function assertDatabaseHasCommand(int $targetId, string $targetType, string $targetName): void
+    {
+        $this->assertDatabaseHas('commands', [
+            'target_id' => $targetId,
+            'target_type' => $targetType,
+            'target_name' => $targetName,
+        ]);
+    }
+}

--- a/src/tests/Feature/Api/ExecResultsControllerTest.php
+++ b/src/tests/Feature/Api/ExecResultsControllerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Command;
+use App\Models\ExecResult;
+use App\Models\TimeTrigger;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ExecResultsControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_自分のトリガーの実行結果をコマンド名付きで取得できる()
+    {
+        $user = User::factory()->create();
+        $command = Command::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'target_name' => '対象コマンド',
+        ]);
+        $trigger = TimeTrigger::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'command_id' => $command->id,
+            'timezone' => '+09:00',
+        ]);
+        ExecResult::factory()->create([
+            'command_id' => $command->id,
+            'trigger_id' => $trigger->id,
+            'exec_time' => '2026-01-01 09:00:00',
+            'response_code' => 200,
+            'response_header' => '{"Content-Type":["application/json"]}',
+            'response_body' => 'ok',
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/exec/result/' . $trigger->id);
+
+        $response->assertStatus(200);
+        $result = $response->json()[0];
+        $this->assertSame(200, $result['response_code']);
+        $this->assertSame('ok', $result['response_body']);
+        $this->assertSame('対象コマンド', $result['command_name']);
+        $this->assertSame('2026-01-01 09:00:00', $result['exec_time']);
+    }
+
+    public function test_負のコマンドIDは端末モード名へ変換される()
+    {
+        $user = User::factory()->create();
+        $trigger = TimeTrigger::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'command_id' => -2,
+            'timezone' => '+09:00',
+        ]);
+        ExecResult::factory()->create([
+            'command_id' => -2,
+            'trigger_id' => $trigger->id,
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/exec/result/' . $trigger->id);
+
+        $response->assertStatus(200);
+        $this->assertSame('マナーモード', $response->json()[0]['command_name']);
+    }
+
+    public function test_他人のトリガーの実行結果は取得できず403になる()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $owner->id, 'target_type' => 'user']);
+        $trigger = TimeTrigger::factory()->create([
+            'target_id' => $owner->id,
+            'target_type' => 'user',
+            'command_id' => $command->id,
+        ]);
+
+        $response = $this->actingAs($other, 'api')->getJson('/api/exec/result/' . $trigger->id);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_存在しないトリガーIDの結果取得は現状エラーになる()
+    {
+        // CommandsControllerTest と同様、find() が null を返した後に
+        // null のプロパティを読むため警告が例外化され処理が止まる現行仕様の回帰テスト。
+        $user = User::factory()->create();
+
+        $this->withoutExceptionHandling();
+        $this->expectException(\ErrorException::class);
+
+        $this->actingAs($user, 'api')->getJson('/api/exec/result/999999');
+    }
+}

--- a/src/tests/Feature/Api/OnetimeSkipsControllerTest.php
+++ b/src/tests/Feature/Api/OnetimeSkipsControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Command;
+use App\Models\OnetimeSkip;
+use App\Models\TimeTrigger;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class OnetimeSkipsControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function createTimeTriggerFor(User $user): TimeTrigger
+    {
+        $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+
+        return TimeTrigger::factory()->create([
+            'target_id' => $user->id,
+            'target_type' => 'user',
+            'command_id' => $command->id,
+        ]);
+    }
+
+    public function test_未使用と使用済みのスキップ件数を返す()
+    {
+        $user = User::factory()->create();
+        $trigger = $this->createTimeTriggerFor($user);
+        OnetimeSkip::factory()->count(2)->create(['target_id' => $trigger->id, 'target_type' => 'time']);
+        OnetimeSkip::factory()->create(['target_id' => $trigger->id, 'target_type' => 'time', 'deleted_at' => now()]);
+
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/onetime/skip?target_id=' . $trigger->id . '&target_type=time');
+
+        $response->assertStatus(200)->assertExactJson(['skipable_count' => 2, 'skiped_count' => 1]);
+    }
+
+    public function test_他人のトリガーに対する一覧参照は403になる()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $trigger = $this->createTimeTriggerFor($owner);
+
+        $response = $this->actingAs($other, 'api')
+            ->getJson('/api/onetime/skip?target_id=' . $trigger->id . '&target_type=time');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_登録は所有権を確認せず作成できる()
+    {
+        // docs/current-architecture.md 10.2:
+        // 「ワンタイムスキップの参照と削除は対象トリガーの所有権を確認するが、登録は所有権を確認しない」
+        // という現行仕様をそのまま保護する回帰テスト。修正はこのIssueの対象外。
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $trigger = $this->createTimeTriggerFor($owner);
+
+        $response = $this->actingAs($other, 'api')->postJson('/api/onetime/skip', [
+            'target_id' => $trigger->id,
+            'target_type' => 'time',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('onetime_skips', ['target_id' => $trigger->id, 'target_type' => 'time']);
+    }
+
+    public function test_削除は最も古い未使用スキップを対象にする()
+    {
+        $user = User::factory()->create();
+        $trigger = $this->createTimeTriggerFor($user);
+        $older = OnetimeSkip::factory()->create(['target_id' => $trigger->id, 'target_type' => 'time']);
+        $newer = OnetimeSkip::factory()->create(['target_id' => $trigger->id, 'target_type' => 'time']);
+
+        $response = $this->actingAs($user, 'api')->deleteJson('/api/onetime/skip', [
+            'target_id' => $trigger->id,
+            'target_type' => 'time',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertSame(['result', true], $response->json());
+        $this->assertDatabaseMissing('onetime_skips', ['id' => $older->id]);
+        $this->assertDatabaseHas('onetime_skips', ['id' => $newer->id]);
+    }
+
+    public function test_未使用スキップが無い場合は削除結果がfalseになる()
+    {
+        $user = User::factory()->create();
+        $trigger = $this->createTimeTriggerFor($user);
+
+        $response = $this->actingAs($user, 'api')->deleteJson('/api/onetime/skip', [
+            'target_id' => $trigger->id,
+            'target_type' => 'time',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertSame(['result', false], $response->json());
+    }
+
+    public function test_他人のトリガーに対する削除は403になる()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $trigger = $this->createTimeTriggerFor($owner);
+        OnetimeSkip::factory()->create(['target_id' => $trigger->id, 'target_type' => 'time']);
+
+        $response = $this->actingAs($other, 'api')->deleteJson('/api/onetime/skip', [
+            'target_id' => $trigger->id,
+            'target_type' => 'time',
+        ]);
+
+        $response->assertStatus(403);
+    }
+}

--- a/src/tests/Feature/Console/DeleteOldExecResultCommandTest.php
+++ b/src/tests/Feature/Console/DeleteOldExecResultCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\ExecResult;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class DeleteOldExecResultCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_コマンドごとに新しい100件を残し古い実行結果を削除する()
+    {
+        $keptCommandId = 1;
+        $untouchedCommandId = 2;
+        ExecResult::factory()->count(105)->create(['command_id' => $keptCommandId, 'trigger_id' => 1]);
+        ExecResult::factory()->count(50)->create(['command_id' => $untouchedCommandId, 'trigger_id' => 2]);
+
+        Artisan::call('results:delete');
+
+        // id の大きい(新しい)100件だけが残り、古い5件は物理削除されていること
+        $this->assertSame(100, ExecResult::where('command_id', $keptCommandId)->count());
+        $this->assertSame(50, ExecResult::where('command_id', $untouchedCommandId)->count());
+    }
+
+    public function test_ちょうど100件の場合は削除されない()
+    {
+        ExecResult::factory()->count(100)->create(['command_id' => 3, 'trigger_id' => 1]);
+
+        Artisan::call('results:delete');
+
+        $this->assertSame(100, ExecResult::where('command_id', 3)->count());
+    }
+}

--- a/src/tests/Feature/Console/TimeTriggerCommandTest.php
+++ b/src/tests/Feature/Console/TimeTriggerCommandTest.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Calender;
+use App\Models\Command;
+use App\Models\ExecResult;
+use App\Models\OnetimeSkip;
+use App\Models\TimeTrigger;
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\Doubles\FakeHolidayList;
+use Tests\TestCase;
+
+/**
+ * time:trigger は判定にMySQLの NOW() を使うため、PHPのCarbon::setTestNow() では制御できない。
+ * そのためMySQLの `SET timestamp` セッション変数でDB側の現在時刻を固定する
+ * (DatabaseTransactionsがテスト終了時に接続を切断するため、次のテストへ影響しない)。
+ * 一方、祝日判定 (HolidayList 経由) はPHPサーバーの実測 date() を使っており、
+ * これはDB側の固定時刻と独立している(docs/current-architecture.md 10.1 に記載の既知の差異)。
+ * そのため祝日を伴うテストでは、実行時点の実日付をキーにしたFakeHolidayListを都度用意する。
+ */
+class TimeTriggerCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const FIXED_JST_DATETIME = '2026-06-15 10:00:00';
+
+    private function freezeDatabaseNow(string $jstDateTime = self::FIXED_JST_DATETIME): void
+    {
+        $timestamp = Carbon::createFromFormat('Y-m-d H:i:s', $jstDateTime, 'Asia/Tokyo')->getTimestamp();
+        DB::statement('SET timestamp = ' . $timestamp);
+    }
+
+    private function mysqlDayOfWeek(string $jstDateTime = self::FIXED_JST_DATETIME): int
+    {
+        // MySQL DAYOFWEEK(): 1=日曜日 ... 7=土曜日。CarbonのdayOfWeekは0=日曜日 ... 6=土曜日。
+        return Carbon::createFromFormat('Y-m-d H:i:s', $jstDateTime, 'Asia/Tokyo')->dayOfWeek + 1;
+    }
+
+    private function bindMockClient(array $responses): void
+    {
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $this->app->instance(Client::class, new Client(['handler' => $handlerStack]));
+    }
+
+    private function fakeHolidaysForToday(bool $isHoliday, string $countryCode = 'jp'): void
+    {
+        $today = date('Y-m-d');
+        $year = date('Y');
+        $fake = new FakeHolidayList([
+            $countryCode . $year => $isHoliday ? [$today => 'テスト祝日'] : [],
+        ]);
+        $this->app->instance('HolidayList', $fake);
+    }
+
+    private function createTrigger(array $overrides = []): TimeTrigger
+    {
+        $command = Command::factory()->create(['target_id' => 1, 'target_type' => 'user']);
+
+        return TimeTrigger::factory()->create(array_merge([
+            'command_id' => $command->id,
+            'target_id' => 1,
+            'target_type' => 'user',
+            'time_from' => '10:00:00',
+            'time_to' => '10:00:00',
+            'exec_interval' => 1,
+            'target_week' => json_encode([$this->mysqlDayOfWeek()]),
+            'holiday_decision' => 'not_check',
+            'timezone' => '+09:00',
+            'country_code' => 'jp',
+        ], $overrides));
+    }
+
+    public function test_条件を満たすトリガーは実行され結果が保存される()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger();
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+        $result = ExecResult::where('trigger_id', $trigger->id)->first();
+        $this->assertSame(200, $result->response_code);
+        $this->assertSame((string) $trigger->command_id, (string) $result->command_id);
+    }
+
+    public function test_holiday_decisionがexecかつ祝日の場合は実行される()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(true);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['holiday_decision' => 'exec']);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_holiday_decisionがexecかつ祝日でない場合は実行されない()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['holiday_decision' => 'exec']);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_holiday_decisionがnot_execかつ祝日でなく対象曜日の場合は実行される()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['holiday_decision' => 'not_exec']);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_holiday_decisionがnot_execかつ祝日の場合は実行されない()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(true);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['holiday_decision' => 'not_exec']);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_対象曜日でない場合はnot_execでもnot_checkでも実行されない()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $otherWeekday = ($this->mysqlDayOfWeek() % 7) + 1; // 固定時刻の曜日とは異なる曜日
+        $trigger = $this->createTrigger([
+            'holiday_decision' => 'not_check',
+            'target_week' => json_encode([$otherWeekday]),
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_個人カレンダーの祝日上書きはGoogle_Calendarの判定より優先される()
+    {
+        // DB側で固定した日付(target_date)は、PHPサーバーの実日付を使うGoogle Calendar側の
+        // 判定基準日とは独立している(docs/current-architecture.md 10.1)。
+        // ここではGoogle側を非祝日、個人カレンダー側を祝日にして優先順位を確認する。
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['holiday_decision' => 'exec']);
+        Calender::factory()->create([
+            'target_id' => $trigger->target_id,
+            'target_type' => $trigger->target_type,
+            'target_date' => '2026-06-15',
+            'is_holiday' => 1,
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_実行間隔で割り切れない時刻では実行されない()
+    {
+        $this->freezeDatabaseNow(); // 10:00:00
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger([
+            'time_from' => '09:00:00',
+            'time_to' => '23:59:00',
+            'exec_interval' => 7, // 09:00 から 60分後 % 7 = 4 (!= 0)
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_実行間隔で割り切れる時刻では実行される()
+    {
+        $this->freezeDatabaseNow(); // 10:00:00
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger([
+            'time_from' => '09:00:00',
+            'time_to' => '23:59:00',
+            'exec_interval' => 15, // 09:00 から 60分後 % 15 = 0
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_未使用のワンタイムスキップがあれば実行されずスキップが消費される()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger();
+        $skip = OnetimeSkip::factory()->create(['target_id' => $trigger->id, 'target_type' => 'time']);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+        $this->assertNotNull($skip->fresh()->deleted_at);
+    }
+
+    public function test_exec_flagが0のトリガーは対象外になる()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['exec_flag' => 0]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_論理削除済みのトリガーは対象外になる()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger(['deleted_at' => now()]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_同じ分に複数回起動すると重複して実行される()
+    {
+        // docs/current-architecture.md 8.4 に記載された、重複実行を防ぐ仕組みが無い現行仕様の回帰テスト。
+        // 修正はこのIssueの対象外。
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'first'), new Response(200, [], 'second')]);
+        $trigger = $this->createTrigger();
+
+        Artisan::call('time:trigger');
+        Artisan::call('time:trigger');
+
+        $this->assertSame(2, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_年末年始の日付境界でも時間帯と曜日の判定は正しく行われる()
+    {
+        $newYearsEve = '2025-12-31 23:59:00';
+        $this->freezeDatabaseNow($newYearsEve);
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger([
+            'time_from' => '23:59:00',
+            'time_to' => '23:59:00',
+            'target_week' => json_encode([$this->mysqlDayOfWeek($newYearsEve)]),
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_うるう年の2月29日でも時間帯と曜日の判定は正しく行われる()
+    {
+        $leapDay = '2024-02-29 12:00:00';
+        $this->freezeDatabaseNow($leapDay);
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger([
+            'time_from' => '12:00:00',
+            'time_to' => '12:00:00',
+            'target_week' => json_encode([$this->mysqlDayOfWeek($leapDay)]),
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_トリガーのタイムゾーンがAsia_Tokyoと異なる場合も判定に反映される()
+    {
+        // DBの現在時刻は常に+09:00として保持される前提のため、+05:00のトリガーは
+        // 対象タイムゾーンへ変換した時刻(+09:00の4時間前)で時間帯を判定する。
+        $this->freezeDatabaseNow('2026-06-15 10:00:00'); // +09:00 → +05:00 換算で 06:00
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $trigger = $this->createTrigger([
+            'timezone' => '+05:00',
+            'time_from' => '06:00:00',
+            'time_to' => '06:00:00',
+            'target_week' => json_encode([$this->mysqlDayOfWeek('2026-06-15 10:00:00')]),
+        ]);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+}

--- a/src/tests/Feature/Console/UpdateHolidayCacheCommandTest.php
+++ b/src/tests/Feature/Console/UpdateHolidayCacheCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Doubles\FakeHolidayList;
+use Tests\TestCase;
+
+class UpdateHolidayCacheCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_キャッシュをクリアしたうえで当年と翌年の日本の祝日を取得する()
+    {
+        $fake = new FakeHolidayList();
+        $this->app->instance('HolidayList', $fake);
+
+        Artisan::call('holidays:update');
+
+        $this->assertSame(1, $fake->clearedCalls);
+        $this->assertSame(['jp' . date('Y'), 'jp' . (date('Y') + 1)], $fake->requestedKeys);
+    }
+}

--- a/src/tests/Feature/Web/GoogleLoginControllerTest.php
+++ b/src/tests/Feature/Web/GoogleLoginControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as GoogleUser;
+use Mockery;
+use Tests\TestCase;
+
+class GoogleLoginControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function fakeGoogleUser(string $email, string $name = 'テストユーザー', string $token = 'google-token'): GoogleUser
+    {
+        $googleUser = new GoogleUser();
+        $googleUser->email = $email;
+        $googleUser->name = $name;
+        $googleUser->token = $token;
+
+        return $googleUser;
+    }
+
+    public function test_authredirectはGoogleの認証画面へリダイレクトする()
+    {
+        $provider = Mockery::mock();
+        $provider->shouldReceive('redirect')->once()
+            ->andReturn(redirect('https://accounts.google.com/o/oauth2/auth'));
+        Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+        $response = $this->get('/auth/redirect');
+
+        $response->assertRedirect('https://accounts.google.com/o/oauth2/auth');
+    }
+
+    public function test_未登録のGoogleアカウントは新しいグループと所有者ユーザーを作成する()
+    {
+        $googleUser = $this->fakeGoogleUser('new-owner@example.test');
+        $provider = Mockery::mock();
+        $provider->shouldReceive('stateless')->once()->andReturnSelf();
+        $provider->shouldReceive('user')->once()->andReturn($googleUser);
+        Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+        $response = $this->get('/login/callback');
+
+        $response->assertStatus(200);
+        $group = Group::where('email', 'new-owner@example.test')->first();
+        $this->assertNotNull($group);
+        $user = User::where('groups_id', $group->id)->where('owner_flag', true)->first();
+        $this->assertNotNull($user);
+        $response->assertJson([
+            'api_token' => $user->api_token,
+            'user_name' => $user->user_name,
+            'owner_flag' => 1,
+        ]);
+    }
+
+    public function test_既存グループに所有者ユーザーが無い場合は新しい所有者ユーザーを作成する()
+    {
+        $group = Group::factory()->create(['email' => 'existing-group@example.test']);
+        $googleUser = $this->fakeGoogleUser('existing-group@example.test');
+        $provider = Mockery::mock();
+        $provider->shouldReceive('stateless')->once()->andReturnSelf();
+        $provider->shouldReceive('user')->once()->andReturn($googleUser);
+        Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+        $response = $this->get('/login/callback');
+
+        $response->assertStatus(200);
+        $this->assertSame(1, User::where('groups_id', $group->id)->where('owner_flag', true)->count());
+    }
+
+    public function test_既存の所有者ユーザーがいる場合は再利用され重複作成されない()
+    {
+        $group = Group::factory()->create(['email' => 'returning@example.test']);
+        $existingOwner = User::factory()->create(['groups_id' => $group->id, 'owner_flag' => true]);
+        $googleUser = $this->fakeGoogleUser('returning@example.test');
+        $provider = Mockery::mock();
+        $provider->shouldReceive('stateless')->once()->andReturnSelf();
+        $provider->shouldReceive('user')->once()->andReturn($googleUser);
+        Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+        $response = $this->get('/login/callback');
+
+        $response->assertStatus(200);
+        $this->assertSame(1, User::where('groups_id', $group->id)->where('owner_flag', true)->count());
+        $response->assertJson(['api_token' => $existingOwner->api_token]);
+    }
+}


### PR DESCRIPTION
## 目的

Issue #212 の対応。依存関係・PHP・Laravel更新で主要機能が壊れたことをCIで検知できるよう、docs/current-architecture.md（Issue #208）の「12. 後続テストの追加対象」で洗い出した主要ユースケースと既存仕様に回帰テストを追加する。

## 事前確認

- docs/current-architecture.md（Issue #208）の実装・仕様の記載を根拠に対象を決定した。特に「12. 後続テストの追加対象」の10項目、「8. 日付、休日、タイムゾーン、重複実行の現在仕様」、「10. 現状差異」を出発点にした。
- Issue #211 で整備した `make check` をそのままテスト実行の入口として使用し、独自のCI環境は作っていない。
- Issue #209 で残っている人間による本番 `APP_KEY` 照合には触れていない。

## 追加したテスト

`src/tests/Feature/` 配下に追加（既存の `ExampleTest` は変更していない）。

- **Api/ApiAuthenticationTest**: 未認証アクセスは401、`auth:api`（トークンガード）での認証済みアクセスは200、クエリパラメータ経由のトークン認証も成功すること。
- **Api/CalendarControllerTest**: Google Calendar由来の祝日判定、個人カレンダー(`calenders`)による上書きがGoogle側より優先されること（休日→非休日・非休日→休日の両方向）、`type=group`でグループ内共有されること、`type`/`date`欠如時の404、不正な日付文字列を例外にせず1970年として扱う現行挙動、`country_code`指定の優先順位、`upsert`の重複作成防止と新規作成時にLaravelの仕様で201が返る現行挙動。
- **Api/CommandExecControllerTest**: 所有者本人のコマンド実行、他人所有時の403、削除済み/存在しないコマンドの404、まとめ実行での複数コマンド実行、まとめ実行が内包コマンド個々の所有権を確認しない現行仕様、外部HTTPがエラー応答を返した場合の反映、レスポンスを伴わない`RequestException`で現状`TypeError`になる既知の問題（docs 10.4）。
- **Api/CommandsControllerTest**: 一覧のユーザー/グループ対象抽出、一覧の`deleted_at`絞り込みがユーザー対象だけすり抜ける現行クエリの仕様（docs 10.3）、登録時のバリデーション、`target_type`によるtarget_id自動設定、部分更新、認可(403)、存在しないIDでの現状エラー、論理削除。
- **Api/OnetimeSkipsControllerTest**: 未使用/使用済み件数の集計、一覧・削除の認可、登録時に所有権を確認しない現行仕様（docs 10.2）、最古の未使用スキップを対象にした削除。
- **Api/ExecResultsControllerTest**: 実行結果のコマンド名解決（負のコマンドIDの端末モード名変換含む）、認可(403)、存在しないトリガーIDでの現状エラー。
- **Console/TimeTriggerCommandTest**: `time:trigger` の時間帯・実行間隔・曜日・`holiday_decision`各パターン（exec/not_exec/not_check）、個人カレンダー優先、ワンタイムスキップの消費、`exec_flag`/論理削除トリガーの除外、同一分複数起動による重複実行（既存仕様、docs 8.4）、年末年始・うるう年の日付境界、トリガー独自タイムゾーンでの判定。
- **Console/DeleteOldExecResultCommandTest**: コマンドごとに最新100件を保持し古い分を物理削除、ちょうど100件では削除しないこと。
- **Console/UpdateHolidayCacheCommandTest**: キャッシュクリア後に当年・翌年の祝日を取得すること。
- **Web/GoogleLoginControllerTest**: `/auth/redirect`のリダイレクト、新規グループ・所有者ユーザー作成、既存グループへの所有者追加、既存所有者の再利用（重複作成なし）。

外部APIへは一切実通信していない。GuzzleHTTP呼び出しは `GuzzleHttp\Handler\MockHandler` で、`HolidayList`（Google Calendar API連携）はコンテナ経由の差し替え（`Tests\Doubles\FakeHolidayList`）で、Google認証は`Socialite`ファサードのMockeryモックで境界を切っている。

`time:trigger` はMySQLの`NOW()`で判定するため、`Carbon::setTestNow()`では制御できない。そのためテストからMySQLの`SET timestamp`セッション変数でDB側の現在時刻だけを固定し、日付境界・年末年始・うるう年を実行日に依存せず決定的にテストしている（`DatabaseTransactions`がテスト終了時に接続を切断するため次のテストへ影響しない）。一方、祝日判定(`HolidayList`経由)はPHPサーバーの実行時`date()`に依存する現行実装のため、`FakeHolidayList`の辞書は実行時点の実日付をキーに動的に構築し、テストの成否が実行日そのものに依存しないようにしている。

## 本番コードの変更（テスト容易性のため・最小限）

このIssueの主目的はテスト追加だが、以下は既存コードがテスト不可能だったため必要最小限の変更を行った。

1. **`App\Models\User` に `Illuminate\Contracts\Auth\Authenticatable` を実装**（`src/app/Models/User.php`）。従来は素の`Model`を継承しており、Laravelのテストヘルパー `actingAs()` が要求する型を満たさず `TypeError` になっていた。`Illuminate\Auth\Authenticatable` トレイトは追加のメソッドのみを提供し（`getAuthIdentifier`等）、既存の属性・`auth:api`（トークンガード）の挙動・`$hidden`/`$guarded`には影響しない。標準的なLaravelのUserモデル構成に揃える意図もある。
2. **`GuzzleHttp\Client` をコンテナ経由(`app(Client::class)`)で解決**（`CommandExecController::exec()`、`TimeTrigger::handle()`、`AppServiceProvider`に`bind`登録）。従来は `new Client()` を直接生成しており、テストからHTTPレスポンスを差し替える手段がなかった。`AppServiceProvider`では`singleton`ではなく`bind`で登録しており、解決のたびに新しいインスタンスが生成されるため、`CommandExecController::exec()`がコマンドごとに`new Client()`していた従来の生成単位を維持している（まとめ実行で複数コマンドがあっても、それぞれ別のClientインスタンスになる）。テストからは`$this->app->instance(Client::class, ...)`でモック済みClientを差し替える。

これら以外の本番コードは変更していない。ドキュメント化された既存の仕様や既知の課題（削除済みコマンドが一覧に残る、まとめ実行の認可漏れ、重複実行防止が無い、日付境界の不整合、null参照によるエラー等）はテストで「現状の挙動」として保護し、修正はこのIssueの対象外とした。

## 検証（実行コマンドと結果）

- `actionlint .github/workflows/test.yaml` → 指摘なし（`exit=0`）。本PRはワークフローを変更していない。
- `git diff --check main...HEAD` → 指摘なし（`exit=0`）。
- 本PRのPull Request CIで `make check` を3回実行して収束させた。
  - 1回目 [run 30898459372](https://github.com/bvlion/holidays-webhook-server/actions/runs/30898459372): 28 passed, 37 failed。失敗はすべて `actingAs()` の型不一致（`User`が`Authenticatable`未実装）が原因と特定。
  - 2回目 [run 30898823806](https://github.com/bvlion/holidays-webhook-server/actions/runs/30898823806)（Userモデル修正後）: 64 passed, 1 failed。`CalendarControllerTest::test_upsertで同じ対象日に登録すると更新されて重複作成されない` が失敗（Eloquentモデルを直接returnする`upsert`は、Laravelの仕様で新規作成時に自動的に201を返すため、期待値の200が誤りだった）。
  - 3回目 [run 30899137493](https://github.com/bvlion/holidays-webhook-server/actions/runs/30899137493)（期待値を201へ修正後）: **65 passed, 0 failed。CI成功。**
- CIは Issue #211 で整備した固定環境（PHP 8.2.30 / Composer 2.8.12 / MySQL 5.7.35、`make check`）上で実行しており、ローカル検証コマンドとCIの内容は一致している。

## レビュー指摘への対応

1. **認可テストでも外部HTTPへ実通信しないようにする**: `CommandExecControllerTest`に`setUp()`を追加し、既定で応答を持たない空の`MockHandler`付き`Client`を全テストへ登録するようにした。認可・404判定が回帰して実際にHTTPリクエストを送る経路へ入った場合でも、外部ネットワークへは接続せずキューが空のまま例外になりテストが失敗する。個別の応答が必要なテストは従来どおり`bindMockClient()`で明示的に上書きする。
2. **Guzzle Clientの本番ライフサイクルを従来どおりにする**: `AppServiceProvider`の`Client::class`登録を`singleton`から`bind`へ変更した。解決のたびに新しいインスタンスが生成されるため、`CommandExecController::exec()`がコマンドごとに`new Client()`していた従来の生成単位を維持する。テストは`$this->app->instance(Client::class, ...)`で差し替えるため`bind`への変更による影響はない(`TimeTriggerCommandTest`を含め全テストが引き続き成功することを確認済み)。上記「本番コードの変更」欄の説明もあわせて修正した。

### 再検証(実行コマンドと結果)

- `git diff --check main...HEAD` → 指摘なし(`exit=0`)。
- 本PRのPull Request CIで再実行し成功を確認した: [run 30901563538](https://github.com/bvlion/holidays-webhook-server/actions/runs/30901563538) — `make check`成功、**65 passed, 0 failed**(既存65件すべて継続して成功、新規追加テストなし)。
- ローカルの`make check`は、このマシン上で稼働中の個人開発用DBコンテナ(`hw_db`)と衝突・干渉するリスクがあるため実行せず、上記の実PR CI実行(Issue #211で整備した固定環境上の`make check`)を検証の根拠とした。

Closes #212

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
