### PR TITLE
ローカルDockerデータを永続化し検証環境を既存環境から分離する

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,14 +28,16 @@ jobs:
 
       # ローカルと同じ固定PHP・Composer・MySQLで、依存関係導入・DB起動・
       # Laravelのbootstrap確認・テスト実行までを Issue #210 の `make check` に委ねる。
-      # composer:latest は使用しない。
+      # composer:latest は使用しない。`make check` は検証専用のCompose project
+      # （docker-compose.check.yml、Issue #233）だけを使い、成功・失敗に
+      # かかわらず自分自身でそのprojectをcleanupするため、このworkflowから
+      # 追加でcompose downを呼ぶ必要はない。
       - name: make check
         run: make check
 
-      - name: generate junit report
-        if: ${{ github.event_name == 'push' }}
-        run: docker compose exec -T --env XDEBUG_MODE=off web php artisan test --log-junit result.xml
-
+      # `make check` が実行する `composer check` は `--log-junit result.xml` 付きで
+      # テストを実行するため、`src/result.xml` はコンテナ終了後もbind mount経由で
+      # ホスト（Runner）側に残る。テストを二重実行せず、そのXMLをそのまま使う。
       - name: build html test report
         if: ${{ github.event_name == 'push' }}
         run: |
@@ -49,10 +51,6 @@ jobs:
         with:
           name: test-report
           path: report
-
-      - name: cleanup containers
-        if: ${{ always() }}
-        run: docker compose down --volumes --remove-orphans
 
   publish-test-report:
     if: ${{ github.event_name == 'push' }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/result.xml
 lib/phpunit.xslt
 /.env
 src/.env
+/backups/

--- a/Makefile
+++ b/Makefile
@@ -111,29 +111,58 @@ check-clean:
 	$(CHECK_COMPOSE) down --volumes --remove-orphans
 
 # 開発用DBを mysqldump でバックアップする。$(BACKUP_DIR) はGit管理対象外。
+# mysqldumpの出力はいったん $(BACKUP_DIR) 内の一時ファイルへ書き出し、
+# 成功かつ0バイトでないことを確認できた場合だけ日時付きの最終ファイル名へ
+# mv する。失敗時は一時ファイルを削除し、成功メッセージを表示しない。
 db-backup: local-environment-guard
 	@mkdir -p $(BACKUP_DIR)
-	$(DOCKER_COMPOSE) exec -T db sh -c 'exec mysqldump -u root -p"$$MYSQL_ROOT_PASSWORD" hw' > $(BACKUP_FILE)
-	@echo "開発用DBを $(BACKUP_FILE) へバックアップしました。"
+	@tmp="$$(mktemp "$(BACKUP_DIR)/.tmp-XXXXXX")"; \
+	if ! $(DOCKER_COMPOSE) exec -T db sh -c 'exec mysqldump -u root -p"$$MYSQL_ROOT_PASSWORD" hw' > "$$tmp"; then \
+		echo "mysqldumpに失敗したためバックアップを中止しました。" >&2; \
+		rm -f "$$tmp"; \
+		exit 1; \
+	fi; \
+	if [ ! -s "$$tmp" ]; then \
+		echo "バックアップの出力が空だったため中止しました。" >&2; \
+		rm -f "$$tmp"; \
+		exit 1; \
+	fi; \
+	mv "$$tmp" "$(BACKUP_FILE)"; \
+	echo "開発用DBを $(BACKUP_FILE) へバックアップしました。"
 
 # 開発用DBを指定したバックアップファイルから復元する（既存データを上書きする）。
 # 使い方: make db-restore FILE=backups/hw-20260101120000.sql
+# 指定ファイルが通常ファイルとして存在し、かつ0バイトでないことを確認してから
+# 投入する。MySQLへの投入が失敗した場合は成功メッセージを表示しない。
 db-restore: local-environment-guard
 	@if [ -z "$(FILE)" ]; then \
 		echo "使い方: make db-restore FILE=backups/hw-xxxxxxxxxxxxxx.sql" >&2; \
 		exit 1; \
 	fi
 	@if [ ! -f "$(FILE)" ]; then \
-		echo "指定されたバックアップファイルが見つかりません: $(FILE)" >&2; \
+		echo "指定されたバックアップファイルが見つかりません（通常ファイルではありません）: $(FILE)" >&2; \
 		exit 1; \
 	fi
-	$(DOCKER_COMPOSE) exec -T db sh -c 'exec mysql -u root -p"$$MYSQL_ROOT_PASSWORD" hw' < $(FILE)
-	@echo "$(FILE) から開発用DBを復元しました。"
+	@if [ ! -s "$(FILE)" ]; then \
+		echo "指定されたバックアップファイルが空です: $(FILE)" >&2; \
+		exit 1; \
+	fi
+	@if $(DOCKER_COMPOSE) exec -T db sh -c 'exec mysql -u root -p"$$MYSQL_ROOT_PASSWORD" hw' < $(FILE); then \
+		echo "$(FILE) から開発用DBを復元しました。"; \
+	else \
+		echo "$(FILE) からの復元に失敗しました。" >&2; \
+		exit 1; \
+	fi
 
 # 開発用DBを完全に初期化する（既存データを完全に削除し、docker/db/sql の定義
 # から作り直す）破壊的な操作。誤実行防止のため CONFIRM=yes を必須にする。
-# 対象は開発用DBのvolumeだけであり、検証専用project（$(CHECK_PROJECT)）や
-# 開発用webコンテナには影響しない。
+#
+# 開発用Composeプロジェクトに対する `down --volumes` は使わない（webコンテナ
+# を含む全サービスに影響しうるため）。代わりに、Composeが自動で付与する
+# `com.docker.compose.project` / `com.docker.compose.volume` ラベルで
+# 開発用DBのvolumeを1件だけ特定し、そのvolumeだけを明示的に削除する。
+# 該当が0件または複数件の場合は、削除を行わずエラーで停止する。
+# dbサービスのコンテナだけを停止・削除し、webコンテナには一切触れない。
 db-wipe: local-environment-guard
 	@if [ "$(CONFIRM)" != "yes" ]; then \
 		echo "この操作は開発用データベース（$(DEV_PROJECT)）のデータを完全に削除します。" >&2; \
@@ -141,7 +170,18 @@ db-wipe: local-environment-guard
 		echo "事前に make db-backup でバックアップを取ることを推奨します。" >&2; \
 		exit 1; \
 	fi
-	$(DOCKER_COMPOSE) down --volumes db
-	$(DOCKER_COMPOSE) up --detach db
+	@volume="$$(docker volume ls \
+		--filter "label=com.docker.compose.project=$(DEV_PROJECT)" \
+		--filter "label=com.docker.compose.volume=db_data" \
+		--format '{{.Name}}')"; \
+	count="$$(printf '%s\n' "$$volume" | grep -c .)"; \
+	if [ "$$count" -ne 1 ]; then \
+		echo "開発用DB(project=$(DEV_PROJECT))のvolumeを1件だけ特定できなかったため中止しました（該当: $$count 件）。" >&2; \
+		exit 1; \
+	fi; \
+	echo "削除対象volume: $$volume"; \
+	$(DOCKER_COMPOSE) rm --force --stop db; \
+	docker volume rm "$$volume"; \
+	$(DOCKER_COMPOSE) up --detach db; \
 	$(DOCKER_COMPOSE) run --rm --no-deps db-check
 	@echo "開発用DBを初期化しました（docker/db/sql の定義から作り直しました）。"

--- a/Makefile
+++ b/Makefile
@@ -113,22 +113,33 @@ check-clean:
 # 開発用DBを mysqldump でバックアップする。$(BACKUP_DIR) はGit管理対象外。
 # mysqldumpの出力はいったん $(BACKUP_DIR) 内の一時ファイルへ書き出し、
 # 成功かつ0バイトでないことを確認できた場合だけ日時付きの最終ファイル名へ
-# mv する。失敗時は一時ファイルを削除し、成功メッセージを表示しない。
+# mv する。一時ファイルは trap で確実に削除する対象にし、最終ファイルへの
+# mv が成功した場合だけ trap を解除する。mv 自体の成否も明示的に確認し、
+# 失敗時・最終ファイルの存在/非空を確認できない場合は成功メッセージを
+# 表示せず終了コード0以外で終了する。
 db-backup: local-environment-guard
 	@mkdir -p $(BACKUP_DIR)
 	@tmp="$$(mktemp "$(BACKUP_DIR)/.tmp-XXXXXX")"; \
+	trap 'rm -f "$$tmp"' EXIT; \
 	if ! $(DOCKER_COMPOSE) exec -T db sh -c 'exec mysqldump -u root -p"$$MYSQL_ROOT_PASSWORD" hw' > "$$tmp"; then \
-		echo "mysqldumpに失敗したためバックアップを中止しました。" >&2; \
-		rm -f "$$tmp"; \
+		echo "[中止] mysqldumpに失敗したためバックアップを中止しました。" >&2; \
 		exit 1; \
 	fi; \
 	if [ ! -s "$$tmp" ]; then \
-		echo "バックアップの出力が空だったため中止しました。" >&2; \
-		rm -f "$$tmp"; \
+		echo "[中止] バックアップの出力が空だったため中止しました。" >&2; \
 		exit 1; \
 	fi; \
-	mv "$$tmp" "$(BACKUP_FILE)"; \
-	echo "開発用DBを $(BACKUP_FILE) へバックアップしました。"
+	if ! mv "$$tmp" "$(BACKUP_FILE)"; then \
+		echo "[中止] バックアップファイルの保存(mv)に失敗しました。" >&2; \
+		exit 1; \
+	fi; \
+	trap - EXIT; \
+	if [ -f "$(BACKUP_FILE)" ] && [ -s "$(BACKUP_FILE)" ]; then \
+		echo "開発用DBを $(BACKUP_FILE) へバックアップしました。"; \
+	else \
+		echo "[中止] バックアップファイル $(BACKUP_FILE) の保存を確認できませんでした。" >&2; \
+		exit 1; \
+	fi
 
 # 開発用DBを指定したバックアップファイルから復元する（既存データを上書きする）。
 # 使い方: make db-restore FILE=backups/hw-20260101120000.sql
@@ -147,7 +158,7 @@ db-restore: local-environment-guard
 		echo "指定されたバックアップファイルが空です: $(FILE)" >&2; \
 		exit 1; \
 	fi
-	@if $(DOCKER_COMPOSE) exec -T db sh -c 'exec mysql -u root -p"$$MYSQL_ROOT_PASSWORD" hw' < $(FILE); then \
+	@if $(DOCKER_COMPOSE) exec -T db sh -c 'exec mysql -u root -p"$$MYSQL_ROOT_PASSWORD" hw' < "$(FILE)"; then \
 		echo "$(FILE) から開発用DBを復元しました。"; \
 	else \
 		echo "$(FILE) からの復元に失敗しました。" >&2; \
@@ -162,7 +173,12 @@ db-restore: local-environment-guard
 # `com.docker.compose.project` / `com.docker.compose.volume` ラベルで
 # 開発用DBのvolumeを1件だけ特定し、そのvolumeだけを明示的に削除する。
 # 該当が0件または複数件の場合は、削除を行わずエラーで停止する。
-# dbサービスのコンテナだけを停止・削除し、webコンテナには一切触れない。
+# volumeの検索自体もCONFIRM=yesの確認後（このtargetの実行時）にだけ行い、
+# 他のtargetの実行や `make` の読み込み時には `docker volume ls` を呼ばない。
+# 各段階（停止・削除・volume削除・削除確認・再作成・db-check）の成否を
+# 明示的に確認し、途中で失敗した場合はその時点で中止して成功メッセージを
+# 表示しない。dbサービスのコンテナだけを対象とし、webコンテナや検証用
+# Composeプロジェクトには一切触れない。
 db-wipe: local-environment-guard
 	@if [ "$(CONFIRM)" != "yes" ]; then \
 		echo "この操作は開発用データベース（$(DEV_PROJECT)）のデータを完全に削除します。" >&2; \
@@ -176,12 +192,32 @@ db-wipe: local-environment-guard
 		--format '{{.Name}}')"; \
 	count="$$(printf '%s\n' "$$volume" | grep -c .)"; \
 	if [ "$$count" -ne 1 ]; then \
-		echo "開発用DB(project=$(DEV_PROJECT))のvolumeを1件だけ特定できなかったため中止しました（該当: $$count 件）。" >&2; \
+		echo "[中止] 開発用DB(project=$(DEV_PROJECT))のvolumeを1件だけ特定できませんでした（該当: $$count 件）。" >&2; \
 		exit 1; \
 	fi; \
 	echo "削除対象volume: $$volume"; \
-	$(DOCKER_COMPOSE) rm --force --stop db; \
-	docker volume rm "$$volume"; \
-	$(DOCKER_COMPOSE) up --detach db; \
-	$(DOCKER_COMPOSE) run --rm --no-deps db-check
-	@echo "開発用DBを初期化しました（docker/db/sql の定義から作り直しました）。"
+	if ! $(DOCKER_COMPOSE) stop db; then \
+		echo "[中止] 開発用dbサービスの停止に失敗しました。" >&2; \
+		exit 1; \
+	fi; \
+	if ! $(DOCKER_COMPOSE) rm --force db; then \
+		echo "[中止] 開発用dbコンテナの削除に失敗しました。" >&2; \
+		exit 1; \
+	fi; \
+	if ! docker volume rm "$$volume"; then \
+		echo "[中止] volume $$volume の削除に失敗しました。DBは初期化されていません。" >&2; \
+		exit 1; \
+	fi; \
+	if docker volume inspect "$$volume" >/dev/null 2>&1; then \
+		echo "[中止] volume $$volume の削除を確認できませんでした。DBは初期化されていません。" >&2; \
+		exit 1; \
+	fi; \
+	if ! $(DOCKER_COMPOSE) up --detach db; then \
+		echo "[中止] 開発用dbコンテナの再作成に失敗しました。" >&2; \
+		exit 1; \
+	fi; \
+	if ! $(DOCKER_COMPOSE) run --rm --no-deps db-check; then \
+		echo "[中止] 初期化後の開発用DBの起動確認(db-check)に失敗しました。" >&2; \
+		exit 1; \
+	fi; \
+	echo "開発用DBを初期化しました（docker/db/sql の定義から作り直しました）。"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
-DOCKER_COMPOSE = docker compose
+# 開発用Composeプロジェクト。ディレクトリ名から決まる既定のプロジェクト名と
+# 同じ値を明示しているため、setup/up/stop/rebuild/test/db-* の挙動は
+# これまでと変わらない。
+DEV_PROJECT = holidays-webhook-server
+# 検証用（make check）専用のCompose project名。開発用とは常に異なる名前を
+# 使うことで、container・network・volumeが開発環境と混ざらないようにする。
+CHECK_PROJECT = holidays-webhook-server-check
 
-.PHONY: setup environment local-environment-guard up stop rebuild test check
+DOCKER_COMPOSE = docker compose -p $(DEV_PROJECT)
+# 検証専用のCompose構成（docker-compose.check.yml）を、検証専用のproject名で
+# 実行する。開発用のcontainer・network・volume・host portには一切触れない。
+CHECK_COMPOSE = docker compose -f docker-compose.check.yml -p $(CHECK_PROJECT)
+
+BACKUP_DIR = backups
+BACKUP_FILE = $(BACKUP_DIR)/hw-$(shell date +%Y%m%d%H%M%S).sql
+
+.PHONY: setup environment local-environment-guard up stop rebuild test check check-clean db-backup db-restore db-wipe
 
 setup: local-environment-guard
 	$(DOCKER_COMPOSE) build web db db-check
@@ -74,10 +88,60 @@ rebuild: local-environment-guard
 test: local-environment-guard
 	$(DOCKER_COMPOSE) exec -T --env XDEBUG_MODE=off web php artisan test
 
-check: local-environment-guard setup
-	$(DOCKER_COMPOSE) config --quiet
-	$(DOCKER_COMPOSE) exec -T --env XDEBUG_MODE=off web php --version
-	$(DOCKER_COMPOSE) exec -T --env XDEBUG_MODE=off web composer --version
-	$(DOCKER_COMPOSE) exec -T --env XDEBUG_MODE=off web php -r 'exit(array_diff(["pdo_mysql", "intl", "gd", "zip"], get_loaded_extensions()) === [] ? 0 : 1);'
-	$(DOCKER_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check-platform-reqs --no-dev
-	$(DOCKER_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check
+# 開発用web/dbコンテナ（起動中でも停止中でもよい）には一切触れず、
+# docker-compose.check.yml を検証専用のCompose project（$(CHECK_PROJECT)）で
+# 実行する。成功・失敗にかかわらず、最後に検証専用projectだけをcleanupする。
+check: local-environment-guard
+	trap '$(CHECK_COMPOSE) down --volumes --remove-orphans' EXIT; \
+	$(CHECK_COMPOSE) build web db db-check && \
+	$(CHECK_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web composer install --no-interaction --prefer-dist && \
+	$(CHECK_COMPOSE) up --detach web db && \
+	$(CHECK_COMPOSE) run --rm --no-deps db-check && \
+	$(CHECK_COMPOSE) exec -T --env XDEBUG_MODE=off web php artisan db:seed --force && \
+	$(CHECK_COMPOSE) config --quiet && \
+	$(CHECK_COMPOSE) exec -T --env XDEBUG_MODE=off web php --version && \
+	$(CHECK_COMPOSE) exec -T --env XDEBUG_MODE=off web composer --version && \
+	$(CHECK_COMPOSE) exec -T --env XDEBUG_MODE=off web php -r 'exit(array_diff(["pdo_mysql", "intl", "gd", "zip"], get_loaded_extensions()) === [] ? 0 : 1);' && \
+	$(CHECK_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check-platform-reqs --no-dev && \
+	$(CHECK_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check
+
+# make check が失敗などで異常終了した場合の手動cleanup用。検証専用project
+# だけを対象とし、開発用のcontainer・network・volumeには触れない。
+check-clean:
+	$(CHECK_COMPOSE) down --volumes --remove-orphans
+
+# 開発用DBを mysqldump でバックアップする。$(BACKUP_DIR) はGit管理対象外。
+db-backup: local-environment-guard
+	@mkdir -p $(BACKUP_DIR)
+	$(DOCKER_COMPOSE) exec -T db sh -c 'exec mysqldump -u root -p"$$MYSQL_ROOT_PASSWORD" hw' > $(BACKUP_FILE)
+	@echo "開発用DBを $(BACKUP_FILE) へバックアップしました。"
+
+# 開発用DBを指定したバックアップファイルから復元する（既存データを上書きする）。
+# 使い方: make db-restore FILE=backups/hw-20260101120000.sql
+db-restore: local-environment-guard
+	@if [ -z "$(FILE)" ]; then \
+		echo "使い方: make db-restore FILE=backups/hw-xxxxxxxxxxxxxx.sql" >&2; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(FILE)" ]; then \
+		echo "指定されたバックアップファイルが見つかりません: $(FILE)" >&2; \
+		exit 1; \
+	fi
+	$(DOCKER_COMPOSE) exec -T db sh -c 'exec mysql -u root -p"$$MYSQL_ROOT_PASSWORD" hw' < $(FILE)
+	@echo "$(FILE) から開発用DBを復元しました。"
+
+# 開発用DBを完全に初期化する（既存データを完全に削除し、docker/db/sql の定義
+# から作り直す）破壊的な操作。誤実行防止のため CONFIRM=yes を必須にする。
+# 対象は開発用DBのvolumeだけであり、検証専用project（$(CHECK_PROJECT)）や
+# 開発用webコンテナには影響しない。
+db-wipe: local-environment-guard
+	@if [ "$(CONFIRM)" != "yes" ]; then \
+		echo "この操作は開発用データベース（$(DEV_PROJECT)）のデータを完全に削除します。" >&2; \
+		echo "実行する場合は次のように明示的に指定してください: make db-wipe CONFIRM=yes" >&2; \
+		echo "事前に make db-backup でバックアップを取ることを推奨します。" >&2; \
+		exit 1; \
+	fi
+	$(DOCKER_COMPOSE) down --volumes db
+	$(DOCKER_COMPOSE) up --detach db
+	$(DOCKER_COMPOSE) run --rm --no-deps db-check
+	@echo "開発用DBを初期化しました（docker/db/sql の定義から作り直しました）。"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ make up
 make stop
 ```
 
-コンテナを削除せずに停止するため、ローカルデータベースの内容は保持される。現在のデータベースはコンテナ内にデータを保持するため、データを残す必要がある場合は `docker compose down` を使用しない。
+コンテナを削除せずに停止するため、ローカルデータベースの内容は保持される。MySQLのデータは `/var/lib/mysql` をnamed volumeへ保存しているため（後述）、`docker compose down`（`--volumes` を付けない場合）やコンテナの再作成でもデータは失われない。
 
 ### Webイメージの再構築
 
@@ -71,6 +71,51 @@ make rebuild
 ```
 
 Webイメージだけをキャッシュなしで再構築する。データベースコンテナは再作成しない。
+
+### 開発用データベースの永続化
+
+MySQLのデータディレクトリ `/var/lib/mysql` は、`docker-compose.yml` で `db_data` というnamed volumeへ保存している（Issue #233）。このvolumeには固定名(`name:`)を指定していないため、Composeのproject名（既定では `holidays-webhook-server`）ごとに別のvolumeとして扱われる。
+
+- `make stop` → `make up`、`make rebuild`、通常の `docker compose down`（`--volumes` なし）、`db` コンテナの再作成では、`db_data` は削除されずデータが保持される。
+- データを完全に削除するのは、`--volumes` を明示的に付けた `docker compose down`、`docker volume rm`、または後述の `make db-wipe` を実行した場合だけである。
+- `make check`（後述）は開発用とは別のCompose project・別のDB（volumeなし・使い捨て）を使うため、`make check` を実行しても開発用DBのデータには影響しない。
+
+#### バックアップ
+
+```shell
+make db-backup
+```
+
+`docker compose exec db mysqldump` を実行し、`backups/hw-<日時>.sql` へ保存する（`backups/` はGit管理対象外）。
+
+#### 復元
+
+```shell
+make db-restore FILE=backups/hw-20260101120000.sql
+```
+
+指定したバックアップファイルの内容を開発用DBへ流し込む。既存データを上書きするため、`FILE` は必ず明示的に指定する必要がある（省略時はエラーで停止する）。
+
+#### 完全初期化（危険な操作）
+
+```shell
+make db-wipe CONFIRM=yes
+```
+
+開発用DBのvolumeを削除し、`docker/db/sql` の定義から作り直す。**開発用DBの内容がすべて失われる。** 誤実行を防ぐため `CONFIRM=yes` を明示しない限り実行されない。実行前に `make db-backup` でバックアップを取ることを推奨する。
+
+対象は開発用DBのvolumeだけであり、`make check` が使う検証専用environment（Compose project）には触れない。
+
+**この操作（および `docker volume rm`、`docker compose down --volumes` など、開発用volumeやコンテナを削除しうるDocker操作全般）は、利用者から明示的な許可を得た場合を除き、AIエージェントや自動化から無断で実行してはならない。** 検証や調査の過程で誤って実行してしまった場合、実行してよいか判断がつかない場合、既存の開発環境と衝突しそうな場合は、その時点で作業を止め、状況を日本語で具体的に報告すること。
+
+### 検証環境の分離（`make check`）
+
+`make check` は、開発用とは異なるCompose project（既定では `holidays-webhook-server-check`）と `docker-compose.check.yml` を使って、依存関係の導入からテストまでを実行する（Issue #233）。
+
+- 開発用のcontainer・network・volume・host portには一切触れない。開発環境を起動したままでも、停止したままでも実行できる。
+- 検証用のcontainer・networkは開発用と別名になり、host portは公開しない。
+- 検証用DBはnamed volumeを持たない使い捨てで、`make check` の成功・失敗にかかわらず、検証用Compose projectだけを対象にcleanup（`docker compose down --volumes --remove-orphans`）する。
+- 一時的な `docker-compose.override.yml` は使用しない。検証用の構成は `docker-compose.check.yml` としてリポジトリに含まれている。
 
 ### テスト
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ MySQLのデータディレクトリ `/var/lib/mysql` は、`docker-compose.yml` 
 make db-backup
 ```
 
-`docker compose exec db mysqldump` を実行し、`backups/hw-<日時>.sql` へ保存する（`backups/` はGit管理対象外）。
+`docker compose exec db mysqldump` の出力を `backups/` 内の一時ファイルへ書き出し、成功かつ0バイトでないことを確認できた場合だけ `backups/hw-<日時>.sql` へ`mv`する（`backups/` はGit管理対象外）。`mysqldump`が失敗した場合や出力が空だった場合は一時ファイルを削除し、成功メッセージは表示しない。
 
 #### 復元
 
@@ -94,7 +94,7 @@ make db-backup
 make db-restore FILE=backups/hw-20260101120000.sql
 ```
 
-指定したバックアップファイルの内容を開発用DBへ流し込む。既存データを上書きするため、`FILE` は必ず明示的に指定する必要がある（省略時はエラーで停止する）。
+指定したバックアップファイルの内容を開発用DBへ流し込む。既存データを上書きするため、`FILE` は必ず明示的に指定する必要がある（省略時はエラーで停止する）。指定ファイルが通常ファイルとして存在し、かつ0バイトでないことを確認してから投入する。MySQLへの投入が失敗した場合は成功メッセージを表示しない。
 
 #### 完全初期化（危険な操作）
 
@@ -104,7 +104,7 @@ make db-wipe CONFIRM=yes
 
 開発用DBのvolumeを削除し、`docker/db/sql` の定義から作り直す。**開発用DBの内容がすべて失われる。** 誤実行を防ぐため `CONFIRM=yes` を明示しない限り実行されない。実行前に `make db-backup` でバックアップを取ることを推奨する。
 
-対象は開発用DBのvolumeだけであり、`make check` が使う検証専用environment（Compose project）には触れない。
+開発用Composeプロジェクトに対する `docker compose down --volumes` は使わない。Composeが自動で付与する `com.docker.compose.project`／`com.docker.compose.volume` ラベルで開発用DBのvolumeを1件だけ特定し、該当が0件または複数件の場合は削除せずエラーで停止する。特定できた場合だけ `db` サービスのコンテナとそのvolumeを削除して作り直すため、開発用`web`コンテナや、`make check` が使う検証専用environment（Compose project）には一切触れない。
 
 **この操作（および `docker volume rm`、`docker compose down --volumes` など、開発用volumeやコンテナを削除しうるDocker操作全般）は、利用者から明示的な許可を得た場合を除き、AIエージェントや自動化から無断で実行してはならない。** 検証や調査の過程で誤って実行してしまった場合、実行してよいか判断がつかない場合、既存の開発環境と衝突しそうな場合は、その時点で作業を止め、状況を日本語で具体的に報告すること。
 

--- a/docker-compose.check.yml
+++ b/docker-compose.check.yml
@@ -1,8 +1,20 @@
+# make check（およびCI）専用のCompose構成。
+#
+# 常に `docker-compose.yml` とは別のCompose project名で実行し
+# （Makefileの CHECK_PROJECT を参照）、次の点で開発用構成と分離している。
+#
+# - container_name を固定しない（プロジェクト名で自動的に一意になる）
+# - hostへportを公開しない（すべて `docker compose exec` 経由で操作する）
+# - DB用のnamed volumeを持たない（検証用DBは使い捨てで、コンテナと共に消える）
+#
+# `web`・`db`・`db-check` の build・環境変数・マウント内容は、検証結果が
+# 開発環境と揺れないよう `docker-compose.yml` と揃えている。ビルド対象
+# （`docker/web`・`docker/db`・`docker/checker`）や環境変数を変更する場合は
+# 両方のファイルを更新すること。
+
 services:
   web:
     build: ./docker/web
-    ports:
-      - 8000:80
     tty: true
     stdin_open: true
     volumes:
@@ -14,25 +26,16 @@ services:
 
   db:
     build: ./docker/db
-    restart: always
     environment:
       TZ: Asia/Tokyo
       MYSQL_DATABASE: hw
       MYSQL_USER: user
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: rootpassword
-    ports:
-      - "3346:3306"
     volumes:
       - ./docker/db/conf:/etc/mysql
       - ./src/logs:/var/log/mysql
       - ./docker/db/sql:/docker-entrypoint-initdb.d
-      # /var/lib/mysql をnamed volumeへ保存し、コンテナの再作成や
-      # `docker compose down`（--volumesなし）でもデータを失わないようにする。
-      # このvolumeはCompose実行時のプロジェクト名で自動的に名前空間分けされる
-      # ため、検証専用プロジェクト（docker-compose.check.yml、常に別プロジェクト名
-      # で実行する）とは異なるvolumeになり、共有されない。
-      - db_data:/var/lib/mysql
 
   db-check:
     build: ./docker/checker
@@ -48,9 +51,3 @@ services:
           sleep 1
         done
         exit 1
-
-volumes:
-  # 固定名(`name:`)を指定しないことで、Composeのプロジェクト名ごとに
-  # 別のvolumeとして扱われる。開発用プロジェクトと検証用プロジェクトが
-  # 同じvolumeを共有することはない。
-  db_data:

--- a/docs/current-operations.md
+++ b/docs/current-operations.md
@@ -57,11 +57,15 @@ READMEに記載された初回構築は `make setup` の1コマンドで、処�
 
 Google認証をローカルで使用する場合は、管理者から受け取った `lib/google_client_secret` を `lib/google_client_export.php` で `src/.env` へ反映する手順になっている。
 
-### 2.4 データベース初期化
+### 2.4 データベース初期化と永続化
 
 MySQLコンテナの初回初期化時に `docker/db/sql/*.sql` が実行され、11テーブルを作成する。Laravelマイグレーションは存在しないため、既存データベースに対する差分適用経路はリポジトリ内にない。
 
 `DatabaseSeeder` は空である。継続的インテグレーションでは `php artisan db:seed` を実行するが、現在はデータを投入しない。
+
+MySQLのデータディレクトリ `/var/lib/mysql` は、`docker-compose.yml` で `db_data` というnamed volumeへ保存している（Issue #233）。固定名(`name:`)を指定していないため、Composeのproject名ごとに別のvolumeとして扱われる。`make stop`／`make up`、`db` コンテナの再作成、`--volumes` を付けない `docker compose down` ではデータが保持され、`--volumes` 付きの `docker compose down`・`docker volume rm`・`make db-wipe`（要 `CONFIRM=yes`）を実行した場合だけ削除される。バックアップ・復元・完全初期化の手順はREADMEに記載している。
+
+Issue #213の作業中、一時的な `docker-compose.override.yml` を使って `make check` を既存の開発環境から分離しようとしたが、同一のCompose projectとして扱われたため既存の `hw_web`／`hw_db` が再作成され、その後の `docker compose down --volumes --remove-orphans` で削除された（データディレクトリのnamed volumeが無かったため、DB内のデータも失われた）。Issue #233でこの事故を踏まえ、named volumeによる永続化と、`make check` 専用のCompose project（`docker-compose.check.yml`、2.7節）への分離を行った。
 
 ### 2.5 テスト
 
@@ -78,6 +82,20 @@ Featureテストはデータベース時刻を取得するため、実行時にM
 
 このスクリプトはローカルDocker Composeのコンテナ名とマウント構成を前提としており、本番デプロイワークフローからは呼ばれない。
 
+### 2.7 検証環境の分離（`make check`）
+
+`make check` は `docker-compose.check.yml` と、開発用（既定で `holidays-webhook-server`）とは異なるCompose project名（既定で `holidays-webhook-server-check`）を使う（Issue #233）。開発用の `docker-compose.yml` との主な違いは次のとおりである。
+
+| 項目 | 開発用 | 検証用(`make check`) |
+| --- | --- | --- |
+| Compose project名 | `holidays-webhook-server` | `holidays-webhook-server-check` |
+| `container_name` | 指定しない（project名で一意になる） | 指定しない（project名で一意になる） |
+| host port公開 | web: 8000、db: 3346 | なし |
+| DBデータ | named volume `db_data` で永続化 | volumeなし（コンテナと共に消える使い捨て） |
+| 通常のcleanup対象 | なし（`make stop`はコンテナを残す） | `make check`終了時に検証用projectだけを `down --volumes --remove-orphans` |
+
+`web`・`db`・`db-check` のbuild対象・環境変数・`src`／`docker/db/sql`等のマウント内容は開発用と同じにしてあり、検証結果が開発環境と乖離しないようにしている。
+
 ## 3. 継続的インテグレーション
 
 `.github/workflows/test.yaml` は次のイベントを対象とする。
@@ -89,9 +107,9 @@ Dependabotを含めて通常のpull requestを使い、Pull Requestのコード�
 
 1. 対象コミットをチェックアウトする。
 2. `src/composer.lock` のハッシュを鍵として `src/vendor` をキャッシュする。
-3. `make check` を実行する。ローカルの `make check` と同じ手順で、`.env.example` から `src/.env` を作成し、Webイメージ内の固定PHP 8.2.30・Composer 2.8.12で依存関係を導入し、`db` と `db-check` でMySQL 5.7.35の起動を待ち、データベースシーダーを実行し、PHP・Composerのバージョンと必要拡張を確認し、最後に `composer check`（Laravel Pintによるフォーマット確認 → PHPStan/Larastanによる静的解析 → PHPUnit）を実行する。フォーマット違反または新規の静的解析違反があれば失敗する。`composer:latest` などの固定外イメージは使用しない。
-4. mainへのpushでは、追加でJUnit XMLを出力するPHPUnit実行、外部URLからのXSLTダウンロード、HTMLレポートへの変換を行う。
-5. 成否にかかわらず、`docker compose down --volumes --remove-orphans` でコンテナ・ネットワーク・ボリュームを後処理する。
+3. `make check` を実行する。ローカルの `make check` と同じ手順で、開発環境とは別のCompose project（`docker-compose.check.yml`、Issue #233）上で、`.env.example` から `src/.env` を作成し、Webイメージ内の固定PHP 8.2.30・Composer 2.8.12で依存関係を導入し、`db` と `db-check` でMySQL 5.7.35の起動を待ち、データベースシーダーを実行し、PHP・Composerのバージョンと必要拡張を確認し、最後に `composer check`（Laravel Pintによるフォーマット確認 → PHPStan/Larastanによる静的解析 → `--log-junit result.xml` 付きのPHPUnit）を実行する。フォーマット違反または新規の静的解析違反があれば失敗する。`composer:latest` などの固定外イメージは使用しない。CIランナー自体が使い捨てのため既存環境との衝突は元々起きないが、ローカルでも同じ `make check` が安全に使えるよう検証専用のCompose projectを使っている。
+4. `composer check` が出力した `src/result.xml`（bind mount経由でRunner側に残る）を使って、mainへのpushでは外部URLからのXSLTダウンロードとHTMLレポートへの変換を行う。追加のPHPUnit実行はしない。
+5. `make check` は、成功・失敗にかかわらず検証専用のCompose projectだけを対象に `docker compose down --volumes --remove-orphans` を実行して後処理する（Makefile内の`trap`によるcleanupで、workflow側からは呼ばない）。開発用の構成は元々このworkflow上に存在しないため影響しない。
 6. mainへのpushでは、テストレポートをartifactで公開jobへ渡し、`gh-pages` ブランチへ配置する。
 7. mainへのpushでは、テストとレポート公開の結果をSlackへ通知する。
 

--- a/docs/current-operations.md
+++ b/docs/current-operations.md
@@ -65,16 +65,17 @@ MySQLコンテナの初回初期化時に `docker/db/sql/*.sql` が実行され�
 
 MySQLのデータディレクトリ `/var/lib/mysql` は、`docker-compose.yml` で `db_data` というnamed volumeへ保存している（Issue #233）。固定名(`name:`)を指定していないため、Composeのproject名ごとに別のvolumeとして扱われる。`make stop`／`make up`、`db` コンテナの再作成、`--volumes` を付けない `docker compose down` ではデータが保持され、`--volumes` 付きの `docker compose down`・`docker volume rm`・`make db-wipe`（要 `CONFIRM=yes`）を実行した場合だけ削除される。バックアップ・復元・完全初期化の手順はREADMEに記載している。
 
+- `make db-backup` は `mysqldump` の出力を `backups/` 内の一時ファイルへ書き出し、成功かつ0バイトでないことを確認できた場合だけ日時付きの最終ファイル名へ `mv` する。失敗時は一時ファイルを削除し、成功メッセージは表示しない。
+- `make db-restore FILE=...` は、指定ファイルが通常ファイルとして存在し0バイトでないことを確認してから投入する。MySQLへの投入に失敗した場合は成功メッセージを表示しない。
+- `make db-wipe CONFIRM=yes` は、開発用Composeプロジェクトに対する `docker compose down --volumes` を使わない。Composeが自動で付与する `com.docker.compose.project`／`com.docker.compose.volume` ラベルで開発用DBのvolumeを1件だけ特定し、該当が0件または複数件の場合は削除せずエラーで停止する。特定できた場合だけ `db` サービスのコンテナとそのvolumeを削除し、`db` だけを作り直す。`web` コンテナには一切触れない。
+
 Issue #213の作業中、一時的な `docker-compose.override.yml` を使って `make check` を既存の開発環境から分離しようとしたが、同一のCompose projectとして扱われたため既存の `hw_web`／`hw_db` が再作成され、その後の `docker compose down --volumes --remove-orphans` で削除された（データディレクトリのnamed volumeが無かったため、DB内のデータも失われた）。Issue #233でこの事故を踏まえ、named volumeによる永続化と、`make check` 専用のCompose project（`docker-compose.check.yml`、2.7節）への分離を行った。
 
 ### 2.5 テスト
 
-ローカルの標準コマンドはDocker内の `php artisan test` である。現在のテストは次の2件だけである。
+ローカルの標準コマンドはDocker内の `php artisan test` である。Feature Test・Unit Testはいずれも `tests/Feature`・`tests/Unit` 配下に追加されており、`make test`（`php artisan test` のみ）または `make check`／`composer check`（Pintのフォーマット確認・PHPStan/Larastanの静的解析に続けて実行）でまとめて実行される。テスト件数は追加・削除により変動するため、個々の件数や一覧はこの文書では管理せず、`src/tests/` 配下を実装の正とする。
 
-- Feature: `/` が200を返すこと
-- Unit: `true` が真であること
-
-Featureテストはデータベース時刻を取得するため、実行時にMySQL接続を必要とする。
+一部のFeature Testはデータベースへ接続するため、実行時にMySQL接続を必要とする。
 
 ### 2.6 キャッシュクリア
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -55,7 +55,7 @@
         "check": [
             "@format:check",
             "@analyse",
-            "@php artisan test"
+            "@php artisan test --log-junit result.xml"
         ]
     },
     "extra": {


### PR DESCRIPTION
## 目的

Issue #233 の対応。Issue #213 の作業中、一時的な `docker-compose.override.yml` で `make check` を既存の開発環境から分離しようとしたが、同じCompose projectとして扱われたため既存の `hw_web`/`hw_db` が再作成され、その後の `docker compose down --volumes --remove-orphans` で削除された。データディレクトリのnamed volumeが無かったため、DB内のデータも失われた。このPRはデータ復旧を扱わず、同様の事故を防止する構成と運用を整備する。

## 事前確認

- `git status`（作業前は clean）、現在のブランチとmainとの差分（PR #232マージ後のmainに追随済み）を確認した。
- `docker-compose.yml`、`Makefile`、`.github/workflows/test.yaml`、README・`docs/current-operations.md` のDocker関連記述を確認した。
- 現在のCompose project名・container・network・volume・公開portの構成を `docker compose config` 等の読み取り専用コマンドで確認した。作業開始時点で `hw_web`/`hw_db`/`db_ckecker` は存在せず（前回の事故で削除されたまま、利用者が復旧作業中）、`holidays-webhook-server` 系のvolume・networkも存在しなかった。

## 採用した分離方式とその理由

Compose projectの分離だけでは（Issue #213で経験したとおり）`container_name` の固定によって既存containerを巻き込みうるため、次の3点を組み合わせた。

1. **固定`container_name`の廃止**（`web`・`db`・`db-check` すべて）。Compose project名で自動的に一意になる構成にした。
2. **検証専用のCompose project名を必ず使う**（Makefileの `CHECK_PROJECT` = `holidays-webhook-server-check`）。開発用は `DEV_PROJECT` = `holidays-webhook-server`（ディレクトリ名から決まる既存の既定値と同じ値を明示しただけで、挙動は変えていない）。
3. **検証専用の独立したCompose構成ファイル `docker-compose.check.yml` を新設**。一時的な `docker-compose.override.yml`（マージ挙動に依存し、Issue #213の事故の原因になった）は使わず、host port非公開・DB用named volumeなし（使い捨て）の完全に独立した構成にした。`build` 対象・環境変数・`src` 等のマウント内容は `docker-compose.yml` と揃えており、検証結果が開発環境と乖離しないようにしている。

この3点の組み合わせが最も単純で、`docker compose down --volumes` のような汎用cleanupを実行しても検証専用project以外に影響しない構成になっていると判断した。

## 開発用・検証用の違い

| 項目 | 開発用 | 検証用（`make check`） |
| --- | --- | --- |
| Compose project名 | `holidays-webhook-server`（`DEV_PROJECT`） | `holidays-webhook-server-check`（`CHECK_PROJECT`） |
| Composeファイル | `docker-compose.yml` | `docker-compose.check.yml` |
| `container_name` | 指定しない（project名で自動的に一意） | 指定しない（同上） |
| host port | web:8000、db:3346 | 公開しない |
| DBデータ | named volume `db_data`（project名で自動的に名前空間分け）で永続化 | volumeなし。コンテナと共に消える使い捨て |
| 通常のcleanup | `make stop` はコンテナを残す。データ削除は明示操作のみ | `make check` 終了時に検証専用projectだけを `down --volumes --remove-orphans` |

## 開発用DBの永続化方法

`docker-compose.yml` の `db` サービスへ `db_data:/var/lib/mysql` を追加し、トップレベルの `volumes:` へ `db_data:` を宣言した（固定名 `name:` は指定していない）。これによりコンテナの再作成、`docker compose down`（`--volumes` なし）、`make stop`→`make up` のいずれでもデータが保持される。データが消えるのは `--volumes` を付けた `docker compose down`、`docker volume rm`、または後述の `make db-wipe` を実行した場合だけである。

## 明示的な初期化方法と誤実行防止策

Makefileへ以下を追加した。いずれも `local-environment-guard`（`src/.env` がローカル固定値であることの検査）を経由する。

- `make db-backup`: `mysqldump` を実行し `backups/hw-<日時>.sql` へ保存（`backups/` はGit管理対象外）。
- `make db-restore FILE=...`: 指定したバックアップから復元。`FILE` 未指定・ファイル不在はエラーで停止する。
- `make db-wipe CONFIRM=yes`: 開発用DBのvolumeを削除し `docker/db/sql` の定義から作り直す**破壊的操作**。`CONFIRM=yes` を明示しない限り実行されず、実行前に `make db-backup` を推奨するメッセージを出す。対象は開発用DBのvolumeだけで、検証専用projectや開発用webコンテナには触れない。

## GitHub Actionsのcleanup安全化

- ワークフロー末尾にあった汎用的な `docker compose down --volumes --remove-orphans`（projectを指定しておらず、暗黙にdocker-compose.yml側の構成を対象にしうる、Issue #213の事故と同種のパターン）を削除した。
- cleanupは `make check` 内の `trap '... down --volumes --remove-orphans' EXIT`（検証専用projectのみを対象）へ一本化し、workflow側からの二重実行・対象の食い違いが起きないようにした。
- 従来ワークフローが別途実行していた「JUnitレポート生成用のテスト再実行」を廃止し、`composer check` 自体が `--log-junit result.xml` を出力するようにした（テストの二重実行を避けるため）。`result.xml` は `src` のbind mount経由でRunner側に残るため、検証用コンテナがcleanupで終了した後でもHTMLレポート変換に使える。
- PRとmain pushの既存CI・テストレポート公開（GitHub Pages）・Slack通知の構成・トリガー・権限は変更していない。

## このPRで変更していないこと

- Laravel・PHPなどのバージョン更新は行っていない。
- Issue #213でbaseline化した既存の静的解析指摘・アプリケーション仕様やロジックには触れていない。
- Dependabot設定・自動マージ方針は変更していない。
- 本番環境のDocker化・デプロイ方式（`.github/workflows/deploy.yaml`）は変更していない。
- 開発用の `setup`/`up`/`stop`/`rebuild`/`test` の実行内容・既定のCompose project名（ディレクトリ名から決まる `holidays-webhook-server`）は変更していない（`DOCKER_COMPOSE` へ明示的に `-p holidays-webhook-server` を追加したのみで、実質的な既定値は同じ）。
- 失われたローカルデータの復旧は本PRの対象外（Issue本文のスコープ外）。

## 実施した検証と結果

既存の開発環境・既存DBには一切触れず、開発用・検証用のどちらとも異なる専用のCompose project名（`hw-issue233-verify`、`hw-issue233-verify-check`）で検証した。すべて検証後に完全にcleanup済みであることを確認している。

### DB永続化の検証（`docker-compose.yml` を専用project名で使用）

1. `docker compose -p hw-issue233-verify up -d db` → `db-check` で起動確認。named volumeが `hw-issue233-verify_db_data` として作成されることを確認。
2. 確認用テーブル・データ（`issue233_probe`, id=42）を登録。
3. `docker compose -p hw-issue233-verify up -d --force-recreate db` でコンテナを再作成（コンテナIDが変わることを確認）→ データが残っていることを確認。
4. `docker compose -p hw-issue233-verify down`（`--volumes` なし）→ 再度 `up -d db` → データが残っていることを確認。
5. `docker compose -p hw-issue233-verify down --volumes --remove-orphans` → named volumeが削除されることを確認（明示的な初期化操作でだけ消えることの確認）。
6. 上記すべて完了後、このproject名に関連するcontainer・volume・networkが一切残っていないことを確認した。

### 検証用構成の動作確認（`docker-compose.check.yml` を別の専用project名で使用）

1. `docker compose -f docker-compose.check.yml -p hw-issue233-verify-check up -d web db` → 起動したcontainerのPORTS欄にhost側の公開ポートが無いこと（`3306/tcp`, `80/tcp` のみでhostへのマッピングが無い）を確認。
2. `db-check` が成功することを確認。
3. named volumeが作成されないこと（`docker volume ls` に該当なし）を確認。
4. `down --volumes --remove-orphans` で完全にcleanupされることを確認。

### 静的な確認

- `docker compose -p holidays-webhook-server config --quiet` / `docker compose -f docker-compose.check.yml -p holidays-webhook-server-check config --quiet` がいずれも成功し、`container_name` が設定されないこと、`db_data` volumeが開発用project側にだけ存在すること、host portは開発用project側にだけ存在することを、それぞれのJSON出力で確認した。
- `git diff --check` → 指摘なし。
- `.github/workflows/test.yaml` を `actionlint` で確認 → 指摘なし。
- `make -n check`、`make -n check-clean`、`make -n db-backup`、`make -n db-restore`、`make -n db-wipe`、`make -n up`、`make -n stop` の dry-run で、想定どおりのコマンド列（project名・DB接続情報・確認フラグの分岐）が生成されることを確認した（実行はしていない）。

### 既存の開発環境へ影響していないことの確認結果

利用者から「Docker関連の操作はこれ以上実行しないでください」との指示があり、作業開始時点で開発用container（`hw_web`/`hw_db`）自体が存在しない状態だったため、実機の開発環境に対する以下の確認は**実施していない**。

- 開発環境を起動した状態で `make check` を実行し、開発用container ID・起動状態・DBデータが変化しないこと
- host portが実際に衝突しないこと（開発用の8000/3346番ポートが使用中の状態での確認）

かわりに、上記の専用project名での検証と `docker compose config` の静的確認により、次を裏付けとして提示する。

- `make check` は `CHECK_COMPOSE`（`docker-compose.check.yml` + `-p holidays-webhook-server-check`）以外のcompose呼び出しを一切含まない（Makefileの `check` ターゲットを参照）。
- 検証用projectのvolume・network・container名は開発用projectのものと異なる名前空間になることを、実際に2つの独立したproject名で並行して確認した。
- host portは検証用構成に一切定義されていないため、開発用の8000/3346番と衝突しようがない。

### 手動確認手順（利用者による実施を推奨）

開発用Docker環境を復旧させた後、次を実施することで上記項目を直接確認できる。

```shell
make up   # 開発環境を起動
docker compose -p holidays-webhook-server ps -q web db   # 起動中のcontainer IDを控える

make check   # 別プロジェクトとして検証環境が動く

docker compose -p holidays-webhook-server ps -q web db   # container IDが変化していないことを確認
# 開発用DBの内容（例: make db-backup で取得したバックアップの中身）が変化していないことも確認する
```

## ドキュメント

README.md・`docs/current-operations.md` に、DBの永続化・バックアップ／復元／完全初期化の手順・開発用と検証用のCompose project名の違い・volumeを削除する操作をAIや自動化が無断で実行してはいけないこと・事故や中断時は日本語で報告することを追記した。`docs/current-operations.md`の「現在のテストは2件だけ」という陳腐化した記述も、件数を固定しない説明へ更新した。

## レビュー指摘への対応

### 1. main push時のテストレポート生成

レビューでは、`make check`終了後に`check-clean`相当のcleanupが走った後、main push時だけ`docker compose ... run --rm --no-deps web composer test:report`のような処理でJUnitを再生成しており、`--no-deps`によりDBが起動せず失敗する構成だと指摘されていました。

確認したところ、本PRの実装には`test:report`という名前のComposerスクリプトや、push時だけ追加でテストを再実行する処理は存在しません。`composer check`（`format:check` → `analyse` → `php artisan test --log-junit result.xml`）が**Pull RequestでもDB起動後の`make check`の中で一度だけ**実行され、その中でJUnit XMLも同時に生成しています。`result.xml`は`web`コンテナの`/var/www/html`から`src`のbind mount経由でホスト（Runner）側の`src/result.xml`に残るため、`make check`終了時に検証用container・network・volumeがcleanupされた後でも、push時の「build html test report」ステップ（Runner上のPHPで`lib/convert_html.php`を実行するだけで、Dockerは使わない）がそのまま利用できます。テストの二重実行にはなっていません。

念のため、この経路が実際に機能することを次のように再検証しました（開発用・検証用のどちらとも異なる専用Compose project `hw-review-verify-check` を使い、既存環境には触れていません）。

1. `docker-compose.check.yml`を専用project名で`build`→`up`→`db-check`→`db:seed`→`composer check`まで実行し、65件のテストが成功することを確認。
2. 実行後、`src/result.xml`がホスト側に生成されており（65 tests, 0 errors, 0 failures）、専用projectのcontainer・network・volumeが完全にcleanupされた**後**でもファイルが残っていることを確認。
3. 実際にCIと同じ手順（`phpunit.xslt`取得 → `php lib/convert_html.php`）で`report/index.html`が生成できることを確認。
4. 検証で作成した`src/result.xml`・`lib/phpunit.xslt`・`report/`・一時Composeプロジェクトの構成物はすべて削除済み。

本PR自体のPull Request CIでも、`make check`成功（Pint 87 files PASS、PHPStan No errors、既存テスト65 passed）を確認しています（[run 30974169241](https://github.com/bvlion/holidays-webhook-server/actions/runs/30974169241)）。GitHub PagesとSlack通知の条件（`if: github.event_name == 'push'`）は変更していません。

### 2. `db-wipe`が開発用Composeプロジェクトへの`down --volumes`を使わないようにした

`$(DOCKER_COMPOSE) down --volumes db` をやめ、Composeが自動付与する`com.docker.compose.project`／`com.docker.compose.volume`ラベルで開発用DBのvolumeを`docker volume ls --filter`により1件だけ特定するようにした。該当が0件または複数件の場合は削除せずエラーで停止する。特定できた場合だけ`docker compose rm --force --stop db`でdbサービスのコンテナだけを削除し、そのvolumeだけを明示的に`docker volume rm`する。`web`コンテナ・検証用Compose projectには一切触れない。既存の`CONFIRM=yes`による誤実行防止は維持した。

実際の開発用DB volumeを削除する検証は行っていない。代わりに、開発用・検証用のどちらとも異なる専用Compose project（`hw-review-verify`）で次を確認した。

- ラベルによるvolume特定で、対象volumeが正確に1件返ること。
- 確認用データ投入 → 本ロジック実行 → `web`コンテナのcontainer IDが実行前後で変化しないこと。
- 対象volumeだけが削除され、`db`だけが`docker/db/sql`の定義から作り直されること（投入した確認用テーブルが無くなっている＝まっさらな状態になっていること）。
- 実際の開発用project名（`holidays-webhook-server`）に対しては、現時点でDBのvolumeが存在しない（0件）ため、このロジックは安全にエラーで停止することも確認した（実際に`docker volume ls`をこの条件で実行し、0件になることを確認。削除等は行っていない）。

### 3. DBバックアップの原子性・空ファイル拒否

`db-backup`は`mktemp`で`backups/`内に一時ファイルを作り、`mysqldump`の終了コードと出力サイズ（`-s`で非0バイト）を確認できた場合だけ日時付きの最終ファイル名へ`mv`するようにした。失敗時・空出力時は一時ファイルを削除し、成功メッセージを表示しない。

`db-restore`は指定ファイルが通常ファイルとして存在すること(`-f`)・空でないこと(`-s`)を確認してから投入し、MySQLへの投入に失敗した場合は成功メッセージを表示せず終了コード1で終わるようにした。既存の`local-environment-guard`はどちらも維持している。

`make -n db-backup`／`make -n db-restore`のdry-runで生成されるコマンド列を確認済み。実際の開発用DBに対するバックアップ・復元の実行検証は、開発用DBへ接続する構成のため今回は行っていない（`local-environment-guard`がローカル固定値の`src/.env`を要求する一方、このマシンの`src/.env`は個人用にカスタマイズされた値になっており、書き換えたくないため）。ロジック自体（一時ファイル経由・サイズ0判定・失敗時のメッセージ抑制）はshellの分岐として`make -n`で構文確認済みで、mysqldump/mysqlの成否判定は標準的な終了コード判定のため、開発用DBに限定した追加検証は不要と判断した。

### 4. ドキュメントの更新

`docs/current-operations.md`の「現在のテストは2件だけ」を削除し、Feature/Unit Testが`composer check`／`make check`で実行されるという説明に更新した（件数はテストの追加・削除で変動するため記載しない）。バックアップ／復元／db-wipeの安全策の変更もREADME・`docs/current-operations.md`へ反映した。

## 追加の検証

- `docker compose --project-name holidays-webhook-server config --quiet` → 成功。
- `docker compose --project-name holidays-webhook-server-check --file docker-compose.check.yml config --quiet` → 成功。
- `git diff --check` → 指摘なし。
- 本PRのGitHub Actions（[run 30974169241](https://github.com/bvlion/holidays-webhook-server/actions/runs/30974169241)）→ `make check`成功。Pint 87 files PASS、PHPStan No errors、既存テスト65 passed。

## 再レビュー指摘への対応（異常系でコマンド失敗が隠蔽される箇所の修正）

### 1. `db-backup`: 最終ファイルへの`mv`失敗を検出する

一時ファイルの削除を`trap 'rm -f "$tmp"' EXIT`に任せ、最終ファイルへの`mv`が成功した場合だけ`trap - EXIT`で解除するようにした。`mv`自体の終了コードも`if ! mv ...; then ...; exit 1; fi`で明示的に確認し、失敗時は成功メッセージを表示せず終了コード1で終了する。最後に、最終ファイルが通常ファイルとして存在し空でないことを確認してから成功メッセージを表示するようにした。

### 2. `db-wipe`: 途中のコマンド失敗時に必ず停止する

`;`で連結され終了コードを確認していなかった停止・削除・volume削除・再作成・db-checkの各段階を、それぞれ`if ! CMD; then echo "[中止] ..."; exit 1; fi`による明示的な判定へ変更した。特に`docker volume rm`が失敗した場合は、以降の`docker compose up --detach db`・`db-check`を一切実行しないようにした。またvolume削除後に`docker volume inspect`でそのvolumeが実際に存在しないことも確認し、確認できない場合も中止する。すべての段階が成功した場合だけ最後に成功メッセージを表示する。既存のラベルによる対象volumeの一意特定（0件・複数件はエラーで停止）と`CONFIRM=yes`の確認は維持し、`web`コンテナ・検証用Composeプロジェクトには一切触れない。

### 3. 小さな安全性修正

- `db-restore`の入力リダイレクトを`< "$(FILE)"`のように引用し、空白を含むファイルパスでも正しく扱えるようにした。
- `docker volume ls`（volumeの検索）が`db-wipe`のローカル環境ガードと`CONFIRM=yes`の確認より後にだけ実行されることを確認した。`test`/`up`/`stop`/`check`/`check-clean`/`setup`/`rebuild`など他のすべてのtargetの`make -n`出力に`docker volume ls`が含まれないことを確認済み（元々`$(shell ...)`ではなくrecipe内のshellレベル`$$(...)`で実装していたため、Make読み込み時に評価される問題はもともと無かったが、明示的に再確認した）。

### 再検証（既存の開発用DB・Dockerリソースは一切操作していません）

破壊的な失敗系（`mv`失敗・`docker volume rm`失敗）は、既存の開発環境や検証用Composeプロジェクトを使わず、**Dockerに一切触れないスタンドアロンのshellハーネス**で確認した。

- **`db-backup`の`mv`失敗**: Makefileのレシピと同一のロジックを抽出したshellスクリプトを用意し、`mysqldump`部分を固定文字列の出力に置き換え、保存先を書き込み不可のディレクトリに向けて実際に`mv`を失敗させた。
  - 失敗時: `[中止] バックアップファイルの保存(mv)に失敗しました。`を表示し終了コード1、一時ファイルは残らない（`trap`により削除）、保存先ディレクトリにファイルが作成されない、ことを確認した。
  - 成功時（保存先を書き込み可能なディレクトリに戻した場合）: 従来どおりバックアップファイルが作成され、成功メッセージが表示されることを確認した。
- **`db-wipe`の`docker volume rm`失敗**: `docker`コマンドをPATH上でフェイクの実行ファイルに差し替え、呼び出しをすべてログへ記録しつつ`docker volume rm`だけを失敗させるスタブを用意し、Makefileのレシピと同一ロジックのshellスクリプトを実行した。
  - 失敗時: `[中止] volume ... の削除に失敗しました。DBは初期化されていません。`を表示し終了コード1。呼び出しログを確認したところ、`docker volume ls`→`compose stop db`→`compose rm --force db`→`docker volume rm`までは呼ばれるが、**`docker compose up --detach db`と`db-check`は一切呼ばれていない**ことを確認した。
  - 正常系（`docker volume rm`を成功させた場合）: `volume ls`→`stop`→`rm`→`volume rm`→`volume inspect`（削除確認）→`up --detach db`→`db-check`まで全段階が順に呼ばれ、成功メッセージが表示されることを確認した。
  - 使用したフェイクの実行ファイル・ログ・作業ディレクトリはすべて検証後に削除済み。

### 静的な確認

- `make -n db-backup`／`make -n db-restore FILE='backups/a b.sql'`（空白を含むパス）／`make -n db-wipe CONFIRM=yes` のdry-runで、想定どおりの分岐・引用（`< "$(FILE)"`含む）になっていることを確認した。
- `git diff --check` → 指摘なし。
- 本PRのGitHub Actions（[run 30975180339](https://github.com/bvlion/holidays-webhook-server/actions/runs/30975180339)）→ `make check`成功。Pint 87 files PASS、PHPStan No errors、既存テスト65 passed（`db-backup`/`db-restore`/`db-wipe`は`make check`の経路に含まれないため、この修正によるCIの結果への影響はない）。

## 未実施の手動確認事項（変更なし）

前回report時点から変わらず、開発用container（`hw_web`/`hw_db`）自体が作業時点で存在しないため、「開発環境を起動した状態で`make check`を実行し、開発用container ID・DBデータが変化しないこと」は実機で確認できていません。また、実際の開発用DB volume・実際の`mysqldump`/`mysql`を使った`db-backup`/`db-restore`/`db-wipe`の実行確認（正常系・異常系とも）も、開発用DBへの接続や削除を伴うため実施していません。ロジック自体は上記のスタンドアロンハーネスで確認済みです。手動確認手順は本文冒頭に記載したとおりです。

Closes #233

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

