### PR TITLE
PHP 8.5互換確認環境をローカル・CIへ追加する

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,15 +98,16 @@ jobs:
             elif grep -q '\[php85-compat-check\] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。' php85-check.log; then
               echo "- PHP 8.5.9環境の構築: 成功"
               echo "- 必要拡張（pdo_mysql・intl・gd・zip）の確認: 成功"
+              echo "- composer validate --strict: 成功"
               echo "- 依存関係インストール（composer install）: **未完了**（下記の既知の非互換のため）"
               echo
               echo "### 検出した既知の阻害パッケージ（Issue #216で追跡中）"
               echo '```'
-              sed -n '/\[php85-compat-check\] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。/,/^\[php85-compat-check\] composer install が完了していないため/p' php85-check.log | sed '1d;$d'
+              sed -n '/\[php85-compat-check\] KNOWN_INCOMPATIBLE_PACKAGES_BEGIN/,/\[php85-compat-check\] KNOWN_INCOMPATIBLE_PACKAGES_END/p' php85-check.log | sed '1d;$d'
               echo '```'
               echo
-              echo "- 未実施: Laravel bootstrap・DB seed・composer:validate・composer:audit・composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnit"
-              echo "- 上記が既知の状態から変化した場合（対象パッケージ・バージョンの不一致、想定外の失敗理由等）は、このジョブ自体が失敗する。"
+              echo "- 未実施: Laravel bootstrap・DB seed・composer:audit・composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnit"
+              echo "- 上記が既知の状態から変化した場合（対象パッケージ・バージョンの不一致、PHP制約の変化、想定外の失敗理由等）は、このジョブ自体が失敗する。"
             elif grep -q '\[php85-compat-check\] composer install に成功しました。' php85-check.log; then
               echo "- composer install に成功しました。bootstrap・DB seed・静的解析・テストまで通常どおり実行しています（詳細はジョブのログを参照）。"
             else

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,14 +52,17 @@ jobs:
           name: test-report
           path: report
 
-  # PHP 8.5系の互換確認（Issue #215）。本番はまだPHP 8.2.30のままで、この
-  # ジョブは`test`ジョブとは独立させ、`publish-test-report`・`notify`の
-  # `needs`にも含めない。現行のLaravel 8・依存関係（nette/schema・nette/utils
-  # がPHPの上限を8.4までしか宣言していない等）はPHP 8.5を正式サポートしておらず、
-  # 本Issueの時点でこのジョブが失敗することは想定内であるため、CI全体や
-  # Slack通知の成功判定をこのジョブの結果で左右させない（non-blocking）。
-  # ただし継続的にCI画面上で結果を確認できるよう、push/pull_requestの両方で
-  # 実行し、`continue-on-error`や`|| true`等で失敗を隠さない。
+  # PHP 8.5系の互換確認（Issue #215）。本番はまだPHP 8.2.30のまま。
+  # `composer install`がIssue #216で追跡中の既知の非互換（nette/schema・
+  # nette/utilsのPHP上限8.4）だけで失敗する現状を、
+  # `src/scripts/php85-compat-check.php`が`composer why-not php <version>
+  # --locked`の構造化出力を根拠に機械的に判定し、既知の状態だけであれば
+  # このジョブ自体は成功で終える（`make check-php85`のexit 0）。
+  # 未知の失敗（想定外の非互換、ネットワーク障害、Docker障害等）では
+  # `make check-php85`がexit 1で終了し、このジョブも失敗する
+  # （`continue-on-error`は使わない。ジョブを独立させただけで
+  # non-blockingとする構成ではない）。既知の非互換が解消されれば
+  # `composer install`が成功し、bootstrap以降も自動的に実行される。
   php85-compat:
     runs-on: ubuntu-latest
     steps:
@@ -74,11 +77,42 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-php85-
 
-      # PHP 8.2.30向けの`make check`と同じ手順を、`docker-compose.check.yml`に
+      # PHP 8.2.30向けの`make check`と近い手順を、`docker-compose.check.yml`に
       # `docker-compose.check-php85.yml`を重ねた専用のCompose project
-      # （holidays-webhook-server-check-php85）でだけ実行する。
+      # （holidays-webhook-server-check-php85）でだけ実行する。出力は
+      # ログとして残しつつ、後続のStep Summary生成でも使うためファイルに保存する。
       - name: make check-php85
-        run: make check-php85
+        run: make check-php85 2>&1 | tee php85-check.log
+
+      # 既知の非互換(Issue #216)を検出しただけなのか、未知の失敗なのかを
+      # ログ上の目印から判定し、GitHub Step Summaryへ明示する。判定結果に
+      # かかわらず必ず実行し（`if: always()`）、失敗時もログを隠さない。
+      - name: PHP 8.5 compatibility summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## PHP 8.5 互換確認（Issue #215）"
+            echo
+            if [ ! -f php85-check.log ]; then
+              echo "ログファイルが見つかりませんでした（ビルド前の初期化に失敗した可能性があります）。"
+            elif grep -q '\[php85-compat-check\] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。' php85-check.log; then
+              echo "- PHP 8.5.9環境の構築: 成功"
+              echo "- 必要拡張（pdo_mysql・intl・gd・zip）の確認: 成功"
+              echo "- 依存関係インストール（composer install）: **未完了**（下記の既知の非互換のため）"
+              echo
+              echo "### 検出した既知の阻害パッケージ（Issue #216で追跡中）"
+              echo '```'
+              sed -n '/\[php85-compat-check\] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。/,/^\[php85-compat-check\] composer install が完了していないため/p' php85-check.log | sed '1d;$d'
+              echo '```'
+              echo
+              echo "- 未実施: Laravel bootstrap・DB seed・composer:validate・composer:audit・composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnit"
+              echo "- 上記が既知の状態から変化した場合（対象パッケージ・バージョンの不一致、想定外の失敗理由等）は、このジョブ自体が失敗する。"
+            elif grep -q '\[php85-compat-check\] composer install に成功しました。' php85-check.log; then
+              echo "- composer install に成功しました。bootstrap・DB seed・静的解析・テストまで通常どおり実行しています（詳細はジョブのログを参照）。"
+            else
+              echo "- **既知の非互換(Issue #216)以外の理由、または想定外の失敗を検出しました。** ジョブのログを確認してください。"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish-test-report:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,6 +52,34 @@ jobs:
           name: test-report
           path: report
 
+  # PHP 8.5系の互換確認（Issue #215）。本番はまだPHP 8.2.30のままで、この
+  # ジョブは`test`ジョブとは独立させ、`publish-test-report`・`notify`の
+  # `needs`にも含めない。現行のLaravel 8・依存関係（nette/schema・nette/utils
+  # がPHPの上限を8.4までしか宣言していない等）はPHP 8.5を正式サポートしておらず、
+  # 本Issueの時点でこのジョブが失敗することは想定内であるため、CI全体や
+  # Slack通知の成功判定をこのジョブの結果で左右させない（non-blocking）。
+  # ただし継続的にCI画面上で結果を確認できるよう、push/pull_requestの両方で
+  # 実行し、`continue-on-error`や`|| true`等で失敗を隠さない。
+  php85-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: cache composer vendor (php8.5)
+        uses: actions/cache@v4
+        with:
+          path: ./src/vendor
+          key: ${{ runner.os }}-composer-php85-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-php85-
+
+      # PHP 8.2.30向けの`make check`と同じ手順を、`docker-compose.check.yml`に
+      # `docker-compose.check-php85.yml`を重ねた専用のCompose project
+      # （holidays-webhook-server-check-php85）でだけ実行する。
+      - name: make check-php85
+        run: make check-php85
+
   publish-test-report:
     if: ${{ github.event_name == 'push' }}
     needs: test

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,19 @@ DOCKER_COMPOSE = docker compose -p $(DEV_PROJECT)
 # 実行する。開発用のcontainer・network・volume・host portには一切触れない。
 CHECK_COMPOSE = docker compose -f docker-compose.check.yml -p $(CHECK_PROJECT)
 
+# PHP 8.5互換確認専用（Issue #215）のCompose project名。開発用・通常の検証用
+# （$(CHECK_PROJECT)）のどちらとも異なる名前にし、container・network・volumeが
+# 混ざらないようにする。
+CHECK_PHP85_PROJECT = holidays-webhook-server-check-php85
+# docker-compose.check.yml（db・db-checkはPHP 8.2.30と共通のまま再利用）に
+# docker-compose.check-php85.yml（webのビルド引数PHP_IMAGEだけ上書き）を
+# 重ねる。host portは公開せず、DB用named volumeも持たない（$(CHECK_COMPOSE)と同様）。
+CHECK_PHP85_COMPOSE = docker compose -f docker-compose.check.yml -f docker-compose.check-php85.yml -p $(CHECK_PHP85_PROJECT)
+
 BACKUP_DIR = backups
 BACKUP_FILE = $(BACKUP_DIR)/hw-$(shell date +%Y%m%d%H%M%S).sql
 
-.PHONY: setup environment local-environment-guard up stop rebuild test check check-clean db-backup db-restore db-wipe
+.PHONY: setup environment local-environment-guard up stop rebuild test check check-php85 check-clean check-php85-clean db-backup db-restore db-wipe
 
 setup: local-environment-guard
 	$(DOCKER_COMPOSE) build web db db-check
@@ -109,6 +118,31 @@ check: local-environment-guard
 # だけを対象とし、開発用のcontainer・network・volumeには触れない。
 check-clean:
 	$(CHECK_COMPOSE) down --volumes --remove-orphans
+
+# PHP 8.5系の互換確認（Issue #215）。開発用・通常の検証用（$(CHECK_PROJECT)）の
+# どちらにも一切触れず、専用のCompose project（$(CHECK_PHP85_PROJECT)）だけを
+# 使う。手順・チェック内容は`check`と同一で、PHPイメージだけが異なる。
+# 現行のLaravel 8・依存関係はPHP 8.5を正式サポートしていないため、途中の
+# いずれかのステップで失敗しうる（意図的に握り潰さない。失敗時もcleanupだけは行う）。
+check-php85: local-environment-guard
+	trap '$(CHECK_PHP85_COMPOSE) down --volumes --remove-orphans' EXIT; \
+	$(CHECK_PHP85_COMPOSE) build web db db-check && \
+	$(CHECK_PHP85_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web composer install --no-interaction --prefer-dist && \
+	$(CHECK_PHP85_COMPOSE) up --detach web db && \
+	$(CHECK_PHP85_COMPOSE) run --rm --no-deps db-check && \
+	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web php artisan db:seed --force && \
+	$(CHECK_PHP85_COMPOSE) config --quiet && \
+	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web php --version && \
+	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web composer --version && \
+	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web php -r 'exit(array_diff(["pdo_mysql", "intl", "gd", "zip"], get_loaded_extensions()) === [] ? 0 : 1);' && \
+	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check-platform-reqs --no-dev && \
+	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check
+
+# make check-php85 が失敗などで異常終了した場合の手動cleanup用。PHP 8.5検証専用
+# projectだけを対象とし、開発用・通常の検証用のcontainer・network・volumeには
+# 触れない。
+check-php85-clean:
+	$(CHECK_PHP85_COMPOSE) down --volumes --remove-orphans
 
 # 開発用DBを mysqldump でバックアップする。$(BACKUP_DIR) はGit管理対象外。
 # mysqldumpの出力はいったん $(BACKUP_DIR) 内の一時ファイルへ書き出し、

--- a/Makefile
+++ b/Makefile
@@ -121,20 +121,37 @@ check-clean:
 
 # PHP 8.5系の互換確認（Issue #215）。開発用・通常の検証用（$(CHECK_PROJECT)）の
 # どちらにも一切触れず、専用のCompose project（$(CHECK_PHP85_PROJECT)）だけを
-# 使う。手順・チェック内容は`check`と同一で、PHPイメージだけが異なる。
-# 現行のLaravel 8・依存関係はPHP 8.5を正式サポートしていないため、途中の
-# いずれかのステップで失敗しうる（意図的に握り潰さない。失敗時もcleanupだけは行う）。
+# 使う。
+#
+# 現行のLaravel 8・依存関係（nette/schema・nette/utils）はPHP 8.5を正式サポート
+# していないため、`composer install`はIssue #216で追跡している既知の理由で失敗
+# する状態が現状である。この既知の状態「だけ」であることを
+# `scripts/php85-compat-check.php`（`composer why-not php <version> --locked`の
+# 構造化出力を根拠に判定）で機械的に確認できた場合に限り、bootstrap以降を
+# 未実施のまま成功として終了する。それ以外の失敗（環境構築自体の失敗、想定外の
+# 非互換、ネットワーク障害等）は`continue-on-error`等で隠さず、通常どおり失敗
+# させる。既知の非互換が解消された場合は`composer install`が成功するため、
+# 以降のbootstrap・DB seed・静的解析・テストまで自動的に実行される。
 check-php85: local-environment-guard
 	trap '$(CHECK_PHP85_COMPOSE) down --volumes --remove-orphans' EXIT; \
 	$(CHECK_PHP85_COMPOSE) build web db db-check && \
-	$(CHECK_PHP85_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web composer install --no-interaction --prefer-dist && \
+	$(CHECK_PHP85_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web php --version && \
+	$(CHECK_PHP85_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web composer --version && \
+	$(CHECK_PHP85_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web php -r 'exit(array_diff(["pdo_mysql", "intl", "gd", "zip"], get_loaded_extensions()) === [] ? 0 : 1);' || exit 1; \
+	$(CHECK_PHP85_COMPOSE) run --rm --no-deps --user "$$(id -u):$$(id -g)" --env COMPOSER_HOME=/tmp/composer --env XDEBUG_MODE=off web php scripts/php85-compat-check.php; \
+	compat_status=$$?; \
+	if [ $$compat_status -eq 2 ]; then \
+		echo "[check-php85] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出したため、bootstrap以降は未実施のまま成功として終了します。" >&2; \
+		exit 0; \
+	fi; \
+	if [ $$compat_status -ne 0 ]; then \
+		echo "[check-php85] composer installが、既知の非互換(Issue #216)以外の理由、または未知の理由で失敗しました。" >&2; \
+		exit 1; \
+	fi; \
 	$(CHECK_PHP85_COMPOSE) up --detach web db && \
 	$(CHECK_PHP85_COMPOSE) run --rm --no-deps db-check && \
 	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web php artisan db:seed --force && \
 	$(CHECK_PHP85_COMPOSE) config --quiet && \
-	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web php --version && \
-	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web composer --version && \
-	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web php -r 'exit(array_diff(["pdo_mysql", "intl", "gd", "zip"], get_loaded_extensions()) === [] ? 0 : 1);' && \
 	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check-platform-reqs --no-dev && \
 	$(CHECK_PHP85_COMPOSE) exec -T --env XDEBUG_MODE=off web composer check
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,13 @@ make check-php85
 
 - `docker/web/Dockerfile` は変更せず、ビルド引数 `PHP_IMAGE` の上書き（`docker-compose.check-php85.yml`、`docker-compose.check.yml` と組み合わせて使う）だけでPHP 8.5イメージを再利用する。`db`・`db-check`（MySQL 5.7.35）は`make check`と共通のまま。
 - 専用のCompose project（`holidays-webhook-server-check-php85`）を使い、開発用・`make check`用のどちらのcontainer・network・volume・host portにも一切触れない。
-- 現在のLaravel 8・依存関係（`nette/schema`・`nette/utils`など）はPHP 8.5を正式サポートしていないため、`make check-php85` は途中の処理（`composer install`）で失敗する状態が既知である。この状態を隠さず、失敗した場合もcleanupだけは行う。詳細・原因の切り分けはIssue #215のPull Requestを参照。
+- 現在のLaravel 8・依存関係（`nette/schema v1.3.2`・`nette/utils v4.0.5`。いずれもPHP上限が8.4）はPHP 8.5を正式サポートしていない。`src/scripts/php85-compat-check.php`が、次をすべて満たす場合に限り「Issue #216で追跡中の既知の非互換」と機械的に判定し、`make check-php85`はこの場合**成功（exit 0）** で終える。
+  - `composer validate --strict` が成功している（Composer設定・composer.lockの不整合ではない）
+  - `composer install` が失敗している
+  - `composer why-not php <実行中のPHPバージョン> --locked` が終了コード1・想定どおりの標準エラーで終了し、その標準出力から抽出した「パッケージ名・ロック済みバージョン・PHP制約」の組が、上記2パッケージと**完全一致**する
+  - 上記のいずれか1つでも一致しない場合（新規の非互換、PHP制約の変化、ネットワーク障害、Composer設定不整合等）は、既知の状態ではない**未知の失敗**として `make check-php85` を失敗させる。
+  - 既知の非互換が解消され `composer install` が成功すれば、bootstrap・DB seed・`composer:validate`/`composer:audit`/`composer:prod-check`・Laravel Pint・PHPStan(Larastan)・PHPUnitまで自動的に実行される。
+  - 詳細・検証結果はIssue #215のPull Requestを参照。
 - 異常終了などでcleanupが行われなかった場合は `make check-php85-clean` で検証専用projectだけを片付けられる。
 
 ### テスト
@@ -187,4 +193,4 @@ composer analyse             # PHPStan/Larastanを実行する
 
 Pull Requestの作成・更新、mainへのpush、Dependabotが作成するPull Requestでは、GitHub Actionsがローカルと同じ固定PHP 8.2.30・Composer 2.8.12・MySQL 5.7.35で `make check` を実行する。`make check` はLaravel Pintによるフォーマット確認、PHPStan/Larastanによる静的解析、既存テストを実行するため、フォーマット違反または新規の静的解析違反があるとCIは失敗する。mainにプッシュした場合だけ、テスト結果を[GitHub Pages](https://bvlion.github.io/holidays-webhook-server/index.html)へアップし、Slackへ通知する。
 
-同じワークフロー内で `php85-compat` ジョブが `make check-php85`（PHP 8.5系での互換確認、前述）を実行する（Issue #215）。このジョブは `test`・`publish-test-report`・`notify`（Slack通知）のいずれの`needs`にも含まれておらず、現時点で失敗しても他のジョブやSlack通知の成否には影響しない（non-blocking）。現行のLaravel 8・依存関係がPHP 8.5を正式サポートしていないための既知の失敗であり、結果はCIの実行結果画面から個別に確認できる。
+同じワークフロー内で `php85-compat` ジョブが `make check-php85`（PHP 8.5系での互換確認、前述）を実行する（Issue #215）。このジョブは `test`・`publish-test-report`・`notify`（Slack通知）のいずれの`needs`にも含まれていないが、それ自体はnon-blockingの理由ではない（GitHub Actionsは失敗したジョブが1つでもあればワークフロー全体を失敗として扱うため）。実際には、`src/scripts/php85-compat-check.php`が「Issue #216で追跡中の既知の非互換（`nette/schema v1.3.2`・`nette/utils v4.0.5`のPHP上限8.4）だけ」であることをパッケージ名・バージョン・PHP制約の完全一致で機械的に確認できた場合に限り、`make check-php85`自体を成功（exit 0）で終える構成にしているため、`php85-compat` ジョブおよびワークフロー全体が成功する。想定外の非互換・ネットワーク障害・Composer設定不整合など、既知の状態と一致しない失敗は`continue-on-error`等で隠さず、`make check-php85`・ジョブ・ワークフロー全体を通常どおり失敗させる。ジョブの実行結果とGitHub Step Summary（環境構築結果・検出した既知の阻害パッケージ・未実施項目等）は、CIの実行結果画面から確認できる。依存関係がPHP 8.5対応版へ更新されれば、bootstrap以降の検証まで自動的に実行されるようになる。

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ make db-wipe CONFIRM=yes
 - 検証用DBはnamed volumeを持たない使い捨てで、`make check` の成功・失敗にかかわらず、検証用Compose projectだけを対象にcleanup（`docker compose down --volumes --remove-orphans`）する。
 - 一時的な `docker-compose.override.yml` は使用しない。検証用の構成は `docker-compose.check.yml` としてリポジトリに含まれている。
 
+### PHP 8.5互換確認環境（`make check-php85`）
+
+本番・開発用は引き続きPHP 8.2.30を使用する。将来のPHP 8.5移行に向けて、`make check`と同じ手順をPHP 8.5系（`php:8.5.9-apache`、固定パッチバージョン）だけで実行できる環境を追加している（Issue #215）。
+
+```shell
+make check-php85
+```
+
+- `docker/web/Dockerfile` は変更せず、ビルド引数 `PHP_IMAGE` の上書き（`docker-compose.check-php85.yml`、`docker-compose.check.yml` と組み合わせて使う）だけでPHP 8.5イメージを再利用する。`db`・`db-check`（MySQL 5.7.35）は`make check`と共通のまま。
+- 専用のCompose project（`holidays-webhook-server-check-php85`）を使い、開発用・`make check`用のどちらのcontainer・network・volume・host portにも一切触れない。
+- 現在のLaravel 8・依存関係（`nette/schema`・`nette/utils`など）はPHP 8.5を正式サポートしていないため、`make check-php85` は途中の処理（`composer install`）で失敗する状態が既知である。この状態を隠さず、失敗した場合もcleanupだけは行う。詳細・原因の切り分けはIssue #215のPull Requestを参照。
+- 異常終了などでcleanupが行われなかった場合は `make check-php85-clean` で検証専用projectだけを片付けられる。
+
 ### テスト
 
 ```shell
@@ -173,3 +186,5 @@ composer analyse             # PHPStan/Larastanを実行する
 ## テスト
 
 Pull Requestの作成・更新、mainへのpush、Dependabotが作成するPull Requestでは、GitHub Actionsがローカルと同じ固定PHP 8.2.30・Composer 2.8.12・MySQL 5.7.35で `make check` を実行する。`make check` はLaravel Pintによるフォーマット確認、PHPStan/Larastanによる静的解析、既存テストを実行するため、フォーマット違反または新規の静的解析違反があるとCIは失敗する。mainにプッシュした場合だけ、テスト結果を[GitHub Pages](https://bvlion.github.io/holidays-webhook-server/index.html)へアップし、Slackへ通知する。
+
+同じワークフロー内で `php85-compat` ジョブが `make check-php85`（PHP 8.5系での互換確認、前述）を実行する（Issue #215）。このジョブは `test`・`publish-test-report`・`notify`（Slack通知）のいずれの`needs`にも含まれておらず、現時点で失敗しても他のジョブやSlack通知の成否には影響しない（non-blocking）。現行のLaravel 8・依存関係がPHP 8.5を正式サポートしていないための既知の失敗であり、結果はCIの実行結果画面から個別に確認できる。

--- a/docker-compose.check-php85.yml
+++ b/docker-compose.check-php85.yml
@@ -1,0 +1,17 @@
+# PHP 8.5系の互換確認専用（Issue #215）。`docker-compose.check.yml` と
+# 組み合わせて使う上乗せ（overlay）ファイルで、単独では使わない。
+#
+#   docker compose -f docker-compose.check.yml -f docker-compose.check-php85.yml \
+#     -p <専用のCompose project名> ...
+#
+# `docker-compose.check.yml` の `web` サービスが使う `docker/web/Dockerfile` の
+# `PHP_IMAGE` ビルド引数だけを上書きし、既定のPHP 8.2.30向けDockerfileや
+# `db`・`db-check` サービス（MySQL 5.7.35）はそのまま再利用する。PHPのバージョンは
+# 再現性のため固定パッチバージョンで指定し、`latest` 等の可変タグは使わない。
+
+services:
+  web:
+    build:
+      context: ./docker/web
+      args:
+        PHP_IMAGE: php:8.5.9-apache

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,6 +1,12 @@
+# 既定はローカル・CIで固定しているPHP 8.2.30。PHP 8.5互換確認環境
+# （docker-compose.check-php85.yml、Issue #215）は、このDockerfileを
+# 変更せずビルド時に PHP_IMAGE だけ上書きして再利用する。
+# FROMで参照するARGはファイル先頭（最初のFROMより前）で宣言する必要がある。
+ARG PHP_IMAGE=php:8.2.30-apache
+
 FROM composer:2.8.12 AS composer
 
-FROM php:8.2.30-apache
+FROM ${PHP_IMAGE}
 
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 

--- a/docs/current-operations.md
+++ b/docs/current-operations.md
@@ -99,14 +99,14 @@ Issue #213の作業中、一時的な `docker-compose.override.yml` を使って
 
 ### 2.8 PHP 8.5互換確認環境（`make check-php85`）
 
-本番・開発用のPHPは引き続き8.2.30のままだが、将来のPHP 8.5移行に向けた互換確認環境を追加した（Issue #215）。`docker/web/Dockerfile` はビルド引数 `PHP_IMAGE`（既定値 `php:8.2.30-apache`、ファイル自体は変更しない）で切り替え可能にし、`docker-compose.check.yml` に `docker-compose.check-php85.yml` を重ねて `PHP_IMAGE=php:8.5.9-apache` を上書きすることで、`db`・`db-check`（MySQL 5.7.35）は共通のまま `web` だけPHP 8.5系にした専用環境（Compose project `holidays-webhook-server-check-php85`）を構築する。手順は `make check` と同一（`check-php85`）で、開発用・`make check` 用のどちらの環境にも一切触れない。
+本番・開発用のPHPは引き続き8.2.30のままだが、将来のPHP 8.5移行に向けた互換確認環境を追加した（Issue #215）。`docker/web/Dockerfile` はビルド引数 `PHP_IMAGE`（既定値 `php:8.2.30-apache`、ファイル自体は変更しない）で切り替え可能にし、`docker-compose.check.yml` に `docker-compose.check-php85.yml` を重ねて `PHP_IMAGE=php:8.5.9-apache` を上書きすることで、`db`・`db-check`（MySQL 5.7.35）は共通のまま `web` だけPHP 8.5系にした専用環境（Compose project `holidays-webhook-server-check-php85`）を構築する。手順は基本的に `make check` と同一（`check-php85`）だが、`composer install` の失敗を「既知の非互換」として扱ってよいかを`src/scripts/php85-compat-check.php`で機械的に判定してから後続を続けるか止めるかを分岐する点が異なる。開発用・`make check` 用のどちらの環境にも一切触れない。
 
 隔離環境で実際に確認した結果、次の状態である。
 
-- イメージのビルド、`pdo_mysql`・`intl`・`gd`・`zip`・`xdebug` の各拡張導入、`php --version`（8.5.9）・`composer --version`（2.8.12）の確認、`composer validate --strict`、`composer:audit`（監査ラッパー経由、44件baseline）はいずれもPHP 8.5.9で成功する。
-- `composer check-platform-reqs` は、`nette/schema`（`league/commonmark`→`league/config`経由の間接依存、ロック済みバージョンが `php 8.1 - 8.4` までしか宣言していない）が原因で失敗する。
-- 上記と同じ理由で `composer install`（`make check-php85` の最初の実質的なステップ）が失敗し、それ以降（Laravel bootstrap・migration・`composer:prod-check`・Pint・PHPStan/Larastan・PHPUnit）は現時点では検証できていない。
-- この問題はアプリケーションコードではなく依存パッケージ側（`nette/schema`・`nette/utils`）に起因し、両パッケージともPHP 8.5をサポートする新しいタグ付きリリースが既に存在することを確認済み。対応方針の詳細はIssue #216へのコメントを参照。
+- イメージのビルド、`pdo_mysql`・`intl`・`gd`・`zip`・`xdebug` の各拡張導入、`php --version`（8.5.9）・`composer --version`（2.8.12）の確認、`composer validate --strict`はいずれもPHP 8.5.9で成功する。
+- `composer install` は、`nette/schema`（`league/commonmark`→`league/config`経由の間接依存、ロック済みバージョン`v1.3.2`が `php 8.1 - 8.4` までしか宣言していない）・`nette/utils`（同じくロック済みバージョン`v4.0.5`が `php 8.0 - 8.4` までしか宣言していない）が原因で失敗する。
+- `php85-compat-check.php`は、`composer install`失敗後に`composer why-not php 8.5.9 --locked`の構造化出力（終了コード・標準エラー・パッケージ名/バージョン/PHP制約）を検証し、上記2件と完全一致する場合だけ「既知の非互換」と判定して`make check-php85`を成功（exit 0）で終える。この場合、Laravel bootstrap・migration・`composer:audit`・`composer:prod-check`・Pint・PHPStan/Larastan・PHPUnitは未実施のまま終わる（`composer:validate`は既知判定より前に必ず実行され成功している）。想定外の非互換・ネットワーク障害・Composer設定不整合等では、既知の状態と一致しないため`make check-php85`は失敗する。
+- この問題はアプリケーションコードではなく依存パッケージ側（`nette/schema`・`nette/utils`）に起因し、両パッケージともPHP 8.5をサポートする新しいタグ付きリリースが既に存在することを確認済み。依存関係が更新されて`composer install`が成功するようになれば、`make check-php85`は自動的にbootstrap以降まで実行する。対応方針の詳細はIssue #216へのコメントを参照。
 
 ## 3. 継続的インテグレーション
 
@@ -124,7 +124,7 @@ Dependabotを含めて通常のpull requestを使い、Pull Requestのコード�
 5. `make check` は、成功・失敗にかかわらず検証専用のCompose projectだけを対象に `docker compose down --volumes --remove-orphans` を実行して後処理する（Makefile内の`trap`によるcleanupで、workflow側からは呼ばない）。開発用の構成は元々このworkflow上に存在しないため影響しない。
 6. mainへのpushでは、テストレポートをartifactで公開jobへ渡し、`gh-pages` ブランチへ配置する。
 7. mainへのpushでは、テストとレポート公開の結果をSlackへ通知する。
-8. 上記1〜7とは別に、`php85-compat` ジョブが専用のCompose project（`holidays-webhook-server-check-php85`）で `make check-php85`（2.8節）を実行する（Issue #215）。このジョブは `test`・テストレポート公開・Slack通知（`notify`）のいずれの `needs` にも含まれておらず、失敗しても他のジョブの成否やSlack通知の内容に影響しない（non-blocking）。現行のLaravel 8・依存関係がPHP 8.5を正式サポートしていないことに由来する既知の失敗であり、`continue-on-error` 等で結果を隠さず、CIの実行結果画面から個別に確認できるようにしている。
+8. 上記1〜7とは別に、`php85-compat` ジョブが専用のCompose project（`holidays-webhook-server-check-php85`）で `make check-php85`（2.8節）を実行する（Issue #215）。このジョブは `test`・テストレポート公開・Slack通知（`notify`）のいずれの `needs` にも含まれていないが、それ自体がnon-blockingの理由ではない（GitHub Actionsは失敗したジョブが1つでもあればワークフロー全体を失敗として扱うため）。実際には、`src/scripts/php85-compat-check.php`が「Issue #216で追跡中の既知の非互換（`nette/schema v1.3.2`・`nette/utils v4.0.5`のPHP上限8.4）だけ」であることをパッケージ名・バージョン・PHP制約の完全一致で機械的に確認できた場合に限り`make check-php85`自体を成功（exit 0）で終える構成にしているため、ジョブおよびワークフロー全体が成功する。想定外の非互換・ネットワーク障害・Composer設定不整合など、既知の状態と一致しない失敗は`continue-on-error` 等で隠さず、`make check-php85`・ジョブ・ワークフロー全体を通常どおり失敗させる。ジョブの結果はログとGitHub Step Summary（環境構築結果・検出した既知の阻害パッケージ・未実施項目等）の両方から確認できる。依存関係がPHP 8.5対応版へ更新されれば、bootstrap以降の検証まで自動的に実行されるようになる。
 
 Pull Requestで実行するテストjobはリポジトリ内容の読み取り権限だけを持ち、Secretを使用しない。`gh-pages` への書き込み権限はmainへのpushでだけ実行する公開jobに限定する。
 

--- a/docs/current-operations.md
+++ b/docs/current-operations.md
@@ -97,6 +97,17 @@ Issue #213の作業中、一時的な `docker-compose.override.yml` を使って
 
 `web`・`db`・`db-check` のbuild対象・環境変数・`src`／`docker/db/sql`等のマウント内容は開発用と同じにしてあり、検証結果が開発環境と乖離しないようにしている。
 
+### 2.8 PHP 8.5互換確認環境（`make check-php85`）
+
+本番・開発用のPHPは引き続き8.2.30のままだが、将来のPHP 8.5移行に向けた互換確認環境を追加した（Issue #215）。`docker/web/Dockerfile` はビルド引数 `PHP_IMAGE`（既定値 `php:8.2.30-apache`、ファイル自体は変更しない）で切り替え可能にし、`docker-compose.check.yml` に `docker-compose.check-php85.yml` を重ねて `PHP_IMAGE=php:8.5.9-apache` を上書きすることで、`db`・`db-check`（MySQL 5.7.35）は共通のまま `web` だけPHP 8.5系にした専用環境（Compose project `holidays-webhook-server-check-php85`）を構築する。手順は `make check` と同一（`check-php85`）で、開発用・`make check` 用のどちらの環境にも一切触れない。
+
+隔離環境で実際に確認した結果、次の状態である。
+
+- イメージのビルド、`pdo_mysql`・`intl`・`gd`・`zip`・`xdebug` の各拡張導入、`php --version`（8.5.9）・`composer --version`（2.8.12）の確認、`composer validate --strict`、`composer:audit`（監査ラッパー経由、44件baseline）はいずれもPHP 8.5.9で成功する。
+- `composer check-platform-reqs` は、`nette/schema`（`league/commonmark`→`league/config`経由の間接依存、ロック済みバージョンが `php 8.1 - 8.4` までしか宣言していない）が原因で失敗する。
+- 上記と同じ理由で `composer install`（`make check-php85` の最初の実質的なステップ）が失敗し、それ以降（Laravel bootstrap・migration・`composer:prod-check`・Pint・PHPStan/Larastan・PHPUnit）は現時点では検証できていない。
+- この問題はアプリケーションコードではなく依存パッケージ側（`nette/schema`・`nette/utils`）に起因し、両パッケージともPHP 8.5をサポートする新しいタグ付きリリースが既に存在することを確認済み。対応方針の詳細はIssue #216へのコメントを参照。
+
 ## 3. 継続的インテグレーション
 
 `.github/workflows/test.yaml` は次のイベントを対象とする。
@@ -113,6 +124,7 @@ Dependabotを含めて通常のpull requestを使い、Pull Requestのコード�
 5. `make check` は、成功・失敗にかかわらず検証専用のCompose projectだけを対象に `docker compose down --volumes --remove-orphans` を実行して後処理する（Makefile内の`trap`によるcleanupで、workflow側からは呼ばない）。開発用の構成は元々このworkflow上に存在しないため影響しない。
 6. mainへのpushでは、テストレポートをartifactで公開jobへ渡し、`gh-pages` ブランチへ配置する。
 7. mainへのpushでは、テストとレポート公開の結果をSlackへ通知する。
+8. 上記1〜7とは別に、`php85-compat` ジョブが専用のCompose project（`holidays-webhook-server-check-php85`）で `make check-php85`（2.8節）を実行する（Issue #215）。このジョブは `test`・テストレポート公開・Slack通知（`notify`）のいずれの `needs` にも含まれておらず、失敗しても他のジョブの成否やSlack通知の内容に影響しない（non-blocking）。現行のLaravel 8・依存関係がPHP 8.5を正式サポートしていないことに由来する既知の失敗であり、`continue-on-error` 等で結果を隠さず、CIの実行結果画面から個別に確認できるようにしている。
 
 Pull Requestで実行するテストjobはリポジトリ内容の読み取り権限だけを持ち、Secretを使用しない。`gh-pages` への書き込み権限はmainへのpushでだけ実行する公開jobに限定する。
 

--- a/src/scripts/php85-compat-check.php
+++ b/src/scripts/php85-compat-check.php
@@ -154,11 +154,16 @@ try {
         fail('composer installの失敗原因（パッケージ名・バージョン・PHP制約）が、Issue #216で追跡している既知の非互換と完全には一致しませんでした。新規または変化した非互換の可能性があるため、未知の失敗として扱います。');
     }
 
+    // GitHub ActionsのStep Summary生成が、メッセージ文言の変化に影響されず
+    // 阻害パッケージ一覧だけを機械的に抽出できるよう、専用の開始・終了
+    // マーカー行で挟んで出力する。マーカー行自体は一覧に含めない。
     fwrite(STDOUT, '[php85-compat-check] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。'.PHP_EOL);
+    fwrite(STDOUT, '[php85-compat-check] KNOWN_INCOMPATIBLE_PACKAGES_BEGIN'.PHP_EOL);
     foreach ($found as $name => $info) {
         fwrite(STDOUT, sprintf('  - %s %s requires php (%s)'.PHP_EOL, $name, $info['version'], $info['phpConstraint']));
     }
-    fwrite(STDOUT, '[php85-compat-check] composer validate --strict は成功しましたが、composer install が完了していないため、Laravel bootstrap・DB seed・composer:audit・composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnitは未実施です。'.PHP_EOL);
+    fwrite(STDOUT, '[php85-compat-check] KNOWN_INCOMPATIBLE_PACKAGES_END'.PHP_EOL);
+    fwrite(STDOUT, '[php85-compat-check] composer validate --strict は成功しました。composer install が完了していないため、Laravel bootstrap・DB seed・composer:audit・composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnitは未実施です。'.PHP_EOL);
 
     exit(2);
 } catch (Throwable $e) {

--- a/src/scripts/php85-compat-check.php
+++ b/src/scripts/php85-compat-check.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHP 8.5互換確認環境（Issue #215）専用。`composer install`を実行し、
+ * 失敗した場合はIssue #216で追跡中の既知の非互換パッケージだけが原因かを
+ * `composer why-not php <version> --locked` の構造化出力で機械的に判定する。
+ *
+ * 終了コードの意味:
+ *   0 = composer install に成功した（以降のbootstrap等を通常どおり実行してよい）
+ *   2 = 既知の非互換だけを検出した（bootstrap以降は未実施のまま成功扱いにしてよい）
+ *   1 = 上記以外（未知の失敗。呼び出し側は必ず失敗として扱うこと）
+ *
+ * 依存パッケージがPHP 8.5対応版へ更新された場合は、このファイルの
+ * KNOWN_INCOMPATIBLE_PACKAGES を更新（該当分を削除、あるいは全削除）すること。
+ * 実際の検出結果とここに列挙した内容が完全一致しない限り、常に終了コード1で
+ * 失敗するため、更新を怠って既知の状態のまま固定化されることはない。
+ */
+const EXPECTED_PHP_VERSION = '8.5.9';
+
+const KNOWN_INCOMPATIBLE_PACKAGES = [
+    'nette/schema' => 'v1.3.2',
+    'nette/utils' => 'v4.0.5',
+];
+
+function fail(string $message): void
+{
+    fwrite(STDERR, '[php85-compat-check] ERROR: '.$message.PHP_EOL);
+    exit(1);
+}
+
+/**
+ * @param  list<string>  $command
+ * @return array{0: string, 1: string, 2: int}
+ */
+function runCommand(array $command): array
+{
+    $process = proc_open($command, [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ], $pipes);
+
+    if ($process === false) {
+        fail('コマンドを起動できませんでした: '.implode(' ', $command));
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $exitCode = proc_close($process);
+
+    return [(string) $stdout, (string) $stderr, $exitCode];
+}
+
+set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    if (PHP_VERSION !== EXPECTED_PHP_VERSION) {
+        fail(sprintf(
+            '想定するPHPバージョン(%s)と実際のPHPバージョン(%s)が一致しません。docker-compose.check-php85.ymlのPHP_IMAGE、またはこのスクリプトのEXPECTED_PHP_VERSIONを確認してください。',
+            EXPECTED_PHP_VERSION,
+            PHP_VERSION
+        ));
+    }
+
+    $composerBinary = getenv('COMPOSER_BINARY');
+    if ($composerBinary === false || $composerBinary === '') {
+        $composerBinary = 'composer';
+    }
+
+    [$installStdout, $installStderr, $installExit] = runCommand([$composerBinary, 'install', '--no-interaction', '--prefer-dist']);
+    fwrite(STDOUT, $installStdout);
+    fwrite(STDERR, $installStderr);
+
+    if ($installExit === 0) {
+        fwrite(STDOUT, '[php85-compat-check] composer install に成功しました。以降のbootstrap・DB seed・静的解析・テストを通常どおり実行してください。'.PHP_EOL);
+        exit(0);
+    }
+
+    fwrite(STDERR, '[php85-compat-check] composer install が失敗しました(exit='.$installExit.')。Issue #216で追跡中の既知の非互換だけが原因かを判定します。'.PHP_EOL);
+
+    [$whyNotStdout, $whyNotStderr, $whyNotExit] = runCommand([$composerBinary, 'why-not', 'php', PHP_VERSION, '--locked', '--no-interaction']);
+
+    // 競合が無い場合、"composer why-not" は exit 0 かつ標準出力が空になる
+    // （メッセージは標準エラーへ出る）。この場合、composer installの失敗は
+    // PHPバージョン制約以外の理由のはずなので、未知の失敗として扱う。
+    if ($whyNotExit === 0) {
+        fwrite(STDERR, $whyNotStdout.$whyNotStderr);
+        fail('composer install は失敗しましたが、composer why-not php '.PHP_VERSION.' はPHPバージョンに起因する既知の競合を報告しませんでした。Issue #216の既知の非互換以外の理由で失敗している可能性があるため、未知の失敗として扱います。');
+    }
+
+    $lines = preg_split('/\R/', trim($whyNotStdout));
+    $found = [];
+    $constraints = [];
+    foreach ($lines as $line) {
+        if (trim($line) === '') {
+            continue;
+        }
+        if (! preg_match('/^(\S+)\s+(\S+)\s+requires php\s+\(([^)]*)\)/', $line, $matches)) {
+            fwrite(STDERR, $whyNotStdout.$whyNotStderr);
+            fail('composer why-not php '.PHP_VERSION.' の出力を解析できませんでした（想定外の行: "'.$line.'"）。既知の非互換(Issue #216)であることを機械的に確認できないため、未知の失敗として扱います。');
+        }
+        $found[$matches[1]] = $matches[2];
+        $constraints[$matches[1]] = $matches[3];
+    }
+
+    if ($found === []) {
+        fwrite(STDERR, $whyNotStdout.$whyNotStderr);
+        fail('composer why-not php '.PHP_VERSION.' がexit '.$whyNotExit.' で終了しましたが、競合パッケージを1件も抽出できませんでした。未知の失敗として扱います。');
+    }
+
+    ksort($found);
+    $expected = KNOWN_INCOMPATIBLE_PACKAGES;
+    ksort($expected);
+
+    if ($found !== $expected) {
+        fwrite(STDERR, '検出された競合: '.json_encode($found, JSON_UNESCAPED_SLASHES).PHP_EOL);
+        fwrite(STDERR, 'Issue #216で既知として登録されている競合: '.json_encode($expected, JSON_UNESCAPED_SLASHES).PHP_EOL);
+        fail('composer installの失敗原因が、Issue #216で追跡している既知の非互換パッケージ・バージョンと完全には一致しませんでした。新規または変化した非互換の可能性があるため、未知の失敗として扱います。');
+    }
+
+    fwrite(STDOUT, '[php85-compat-check] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。'.PHP_EOL);
+    foreach ($found as $name => $version) {
+        fwrite(STDOUT, sprintf('  - %s %s requires php (%s)'.PHP_EOL, $name, $version, $constraints[$name]));
+    }
+    fwrite(STDOUT, '[php85-compat-check] composer install が完了していないため、Laravel bootstrap・DB seed・composer:validate/composer:audit/composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnitは未実施です。'.PHP_EOL);
+
+    exit(2);
+} catch (Throwable $e) {
+    fwrite(STDERR, '[php85-compat-check] 予期しないエラーが発生しました: '.$e->getMessage().PHP_EOL);
+    exit(1);
+}

--- a/src/scripts/php85-compat-check.php
+++ b/src/scripts/php85-compat-check.php
@@ -12,6 +12,13 @@ declare(strict_types=1);
  *   2 = 既知の非互換だけを検出した（bootstrap以降は未実施のまま成功扱いにしてよい）
  *   1 = 上記以外（未知の失敗。呼び出し側は必ず失敗として扱うこと）
  *
+ * 既知条件は「パッケージ名」「ロック済みバージョン」「PHP制約の内容」の
+ * 3要素すべての完全一致で判定する（パッケージ名・バージョンが同じでも
+ * PHP制約の内容が変化していれば未知の状態として扱う）。また、
+ * composer why-not自体の終了コード・標準エラーが想定どおりであることも
+ * 確認し、既知のPHP制約と別のComposerエラーが併存していても
+ * 成功扱いにしない。
+ *
  * 依存パッケージがPHP 8.5対応版へ更新された場合は、このファイルの
  * KNOWN_INCOMPATIBLE_PACKAGES を更新（該当分を削除、あるいは全削除）すること。
  * 実際の検出結果とここに列挙した内容が完全一致しない限り、常に終了コード1で
@@ -20,8 +27,8 @@ declare(strict_types=1);
 const EXPECTED_PHP_VERSION = '8.5.9';
 
 const KNOWN_INCOMPATIBLE_PACKAGES = [
-    'nette/schema' => 'v1.3.2',
-    'nette/utils' => 'v4.0.5',
+    'nette/schema' => ['version' => 'v1.3.2', 'phpConstraint' => '8.1 - 8.4'],
+    'nette/utils' => ['version' => 'v4.0.5', 'phpConstraint' => '8.0 - 8.4'],
 ];
 
 function fail(string $message): void
@@ -54,6 +61,16 @@ function runCommand(array $command): array
     return [(string) $stdout, (string) $stderr, $exitCode];
 }
 
+function composerBinary(): string
+{
+    $composerBinary = getenv('COMPOSER_BINARY');
+    if ($composerBinary === false || $composerBinary === '') {
+        return 'composer';
+    }
+
+    return $composerBinary;
+}
+
 set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
     throw new ErrorException($message, 0, $severity, $file, $line);
 });
@@ -67,12 +84,17 @@ try {
         ));
     }
 
-    $composerBinary = getenv('COMPOSER_BINARY');
-    if ($composerBinary === false || $composerBinary === '') {
-        $composerBinary = 'composer';
+    // Composer設定・composer.lockの整合性は、既知の非互換判定より先に必ず
+    // 確認する。ここが失敗した場合は、既知のPHP非互換とは無関係にComposer
+    // 設定自体が壊れているということなので、常に未知の失敗として扱う。
+    [$validateStdout, $validateStderr, $validateExit] = runCommand([composerBinary(), 'validate', '--strict', '--no-interaction']);
+    fwrite(STDOUT, $validateStdout);
+    if ($validateExit !== 0) {
+        fwrite(STDERR, $validateStderr);
+        fail('composer validate --strict が失敗しました(exit='.$validateExit.')。Composer設定・composer.lockの不整合であり、既知のPHP 8.5非互換(Issue #216)とは無関係の問題です。');
     }
 
-    [$installStdout, $installStderr, $installExit] = runCommand([$composerBinary, 'install', '--no-interaction', '--prefer-dist']);
+    [$installStdout, $installStderr, $installExit] = runCommand([composerBinary(), 'install', '--no-interaction', '--prefer-dist']);
     fwrite(STDOUT, $installStdout);
     fwrite(STDERR, $installStderr);
 
@@ -83,51 +105,60 @@ try {
 
     fwrite(STDERR, '[php85-compat-check] composer install が失敗しました(exit='.$installExit.')。Issue #216で追跡中の既知の非互換だけが原因かを判定します。'.PHP_EOL);
 
-    [$whyNotStdout, $whyNotStderr, $whyNotExit] = runCommand([$composerBinary, 'why-not', 'php', PHP_VERSION, '--locked', '--no-interaction']);
+    [$whyNotStdout, $whyNotStderr, $whyNotExit] = runCommand([composerBinary(), 'why-not', 'php', PHP_VERSION, '--locked', '--no-interaction']);
 
-    // 競合が無い場合、"composer why-not" は exit 0 かつ標準出力が空になる
-    // （メッセージは標準エラーへ出る）。この場合、composer installの失敗は
-    // PHPバージョン制約以外の理由のはずなので、未知の失敗として扱う。
-    if ($whyNotExit === 0) {
+    // "composer why-not"自体の終了コード・標準エラーが想定どおりであることを
+    // 厳密に確認する。想定外の終了コードや、標準エラーに余計な内容（警告・
+    // 別のComposerエラー等）が混ざっている場合は、既知のPHP制約と別の問題が
+    // 併存している可能性があるため、成功扱いにせず未知の失敗として扱う。
+    if ($whyNotExit !== 1) {
         fwrite(STDERR, $whyNotStdout.$whyNotStderr);
-        fail('composer install は失敗しましたが、composer why-not php '.PHP_VERSION.' はPHPバージョンに起因する既知の競合を報告しませんでした。Issue #216の既知の非互換以外の理由で失敗している可能性があるため、未知の失敗として扱います。');
+        fail('composer why-not php '.PHP_VERSION.' が想定外の終了コード('.$whyNotExit.')で終了しました。既知の非互換(Issue #216)の判定に必要な「競合あり」の状態(終了コード1)ではないため、未知の失敗として扱います。');
+    }
+
+    $expectedWhyNotStderr = sprintf('Package "php %s" found in version "%s".', PHP_VERSION, PHP_VERSION);
+    if (trim($whyNotStderr) !== $expectedWhyNotStderr) {
+        fwrite(STDERR, $whyNotStdout.$whyNotStderr);
+        fail('composer why-not php '.PHP_VERSION.' の標準エラーが想定どおりではありませんでした。既知のPHP制約以外のComposerエラーが併存している可能性があるため、未知の失敗として扱います。');
     }
 
     $lines = preg_split('/\R/', trim($whyNotStdout));
     $found = [];
-    $constraints = [];
     foreach ($lines as $line) {
         if (trim($line) === '') {
             continue;
         }
-        if (! preg_match('/^(\S+)\s+(\S+)\s+requires php\s+\(([^)]*)\)/', $line, $matches)) {
+        if (! preg_match('/^(\S+)\s+(\S+)\s+requires php\s+\(([^)]*)\)\s*$/', $line, $matches)) {
             fwrite(STDERR, $whyNotStdout.$whyNotStderr);
-            fail('composer why-not php '.PHP_VERSION.' の出力を解析できませんでした（想定外の行: "'.$line.'"）。既知の非互換(Issue #216)であることを機械的に確認できないため、未知の失敗として扱います。');
+            fail('composer why-not php '.PHP_VERSION.' の標準出力を解析できませんでした（想定外の行: "'.$line.'"）。既知の非互換(Issue #216)であることを機械的に確認できないため、未知の失敗として扱います。');
         }
-        $found[$matches[1]] = $matches[2];
-        $constraints[$matches[1]] = $matches[3];
+        $found[$matches[1]] = ['version' => $matches[2], 'phpConstraint' => $matches[3]];
     }
 
     if ($found === []) {
         fwrite(STDERR, $whyNotStdout.$whyNotStderr);
-        fail('composer why-not php '.PHP_VERSION.' がexit '.$whyNotExit.' で終了しましたが、競合パッケージを1件も抽出できませんでした。未知の失敗として扱います。');
+        fail('composer why-not php '.PHP_VERSION.' が終了コード1で終了しましたが、競合パッケージを1件も抽出できませんでした。未知の失敗として扱います。');
     }
 
     ksort($found);
     $expected = KNOWN_INCOMPATIBLE_PACKAGES;
     ksort($expected);
 
+    // パッケージ名・ロック済みバージョン・PHP制約の内容の3要素すべてが
+    // 完全一致する場合だけ「既知の状態」として扱う。いずれか1つでも
+    // 異なれば（パッケージ・バージョンが同じでもPHP制約の内容が変化した
+    // 場合を含む）、新規または変化した非互換として未知の失敗にする。
     if ($found !== $expected) {
         fwrite(STDERR, '検出された競合: '.json_encode($found, JSON_UNESCAPED_SLASHES).PHP_EOL);
         fwrite(STDERR, 'Issue #216で既知として登録されている競合: '.json_encode($expected, JSON_UNESCAPED_SLASHES).PHP_EOL);
-        fail('composer installの失敗原因が、Issue #216で追跡している既知の非互換パッケージ・バージョンと完全には一致しませんでした。新規または変化した非互換の可能性があるため、未知の失敗として扱います。');
+        fail('composer installの失敗原因（パッケージ名・バージョン・PHP制約）が、Issue #216で追跡している既知の非互換と完全には一致しませんでした。新規または変化した非互換の可能性があるため、未知の失敗として扱います。');
     }
 
     fwrite(STDOUT, '[php85-compat-check] Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました。'.PHP_EOL);
-    foreach ($found as $name => $version) {
-        fwrite(STDOUT, sprintf('  - %s %s requires php (%s)'.PHP_EOL, $name, $version, $constraints[$name]));
+    foreach ($found as $name => $info) {
+        fwrite(STDOUT, sprintf('  - %s %s requires php (%s)'.PHP_EOL, $name, $info['version'], $info['phpConstraint']));
     }
-    fwrite(STDOUT, '[php85-compat-check] composer install が完了していないため、Laravel bootstrap・DB seed・composer:validate/composer:audit/composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnitは未実施です。'.PHP_EOL);
+    fwrite(STDOUT, '[php85-compat-check] composer validate --strict は成功しましたが、composer install が完了していないため、Laravel bootstrap・DB seed・composer:audit・composer:prod-check・Laravel Pint・PHPStan(Larastan)・PHPUnitは未実施です。'.PHP_EOL);
 
     exit(2);
 } catch (Throwable $e) {


### PR DESCRIPTION
## 目的

Issue #215 の対応。本番・開発用のPHP 8.2.30を維持したまま、PHP 8.5系でアプリケーションと各検証ツールを実行できる、ローカル・CI共通の互換確認環境を追加する。

## 事前確認

- 最新の`main`（PR #235マージ後）を取得し、Issue #215・親Issue #207・後続Issue #216を確認した。
- 現在の`docker/web/Dockerfile`・`docker-compose.yml`・`docker-compose.check.yml`・`Makefile`・`.github/workflows/test.yaml`・`src/composer.json`／`composer.lock`・PR #232／#234／#235で導入された検証構成（Pint/PHPStan、Compose分離、監査ラッパー）を確認した。
- `composer.json`に`config.platform.php`等のComposer platform設定は存在せず、`composer.lock`の`platform`キーも`composer.json`の`require.php`（`^7.3|^8.0`）をそのまま反映しているだけであることを確認した（PHP 8.5自体はこの制約に抵触しない）。

## PHP 8.5環境の構成

- 採用バージョン: **`php:8.5.9-apache`**（`latest`等の可変タグではなく固定パッチバージョン）。作業時点でDockerHubから取得できる`php:8.5-apache`の実体が`PHP 8.5.9`だったため、これを固定した。
- `docker/web/Dockerfile`は変更内容を最小にするため、`ARG PHP_IMAGE=php:8.2.30-apache`（ファイル先頭、最初の`FROM`より前で宣言）を追加し、`FROM ${PHP_IMAGE}`に置き換えただけで、既存の行・順序は一切変更していない。ビルド引数を指定しなければ従来どおりPHP 8.2.30になる。
- 新規に`docker-compose.check-php85.yml`を追加した。これは単独では使わない上乗せ（overlay）ファイルで、`docker-compose.check.yml`と組み合わせて`web`サービスの`PHP_IMAGE`ビルド引数だけを上書きする。`db`・`db-check`（MySQL 5.7.35）はPHP 8.2.30用の検証環境と共通のまま再利用する。
- `Makefile`に`check-php85`（本体）・`check-php85-clean`（異常終了時の手動cleanup用）を追加した。手順・ステップの並びは既存の`check`と同一だが、`composer install`の失敗を既知の非互換として扱ってよいかを`src/scripts/php85-compat-check.php`で判定してから後続を続けるか止めるかを分岐する（詳細は後述のレビュー対応の節を参照）。
- `.github/workflows/test.yaml`に`php85-compat`ジョブを追加し、`make check-php85`を実行してGitHub Step Summaryへ結果を記録する。

## PHP 8.2.30環境を維持していること

- `docker/web/Dockerfile`はビルド引数の既定値が従来と同じ`php:8.2.30-apache`になるようにしたのみで、行・命令の順序は変更していない。実際に引数無しでビルドし、`docker build`のログ上で全レイヤーがCACHEDになる（＝内容が変わっていない）ことを確認した。
- 既存の`docker-compose.yml`・`docker-compose.check.yml`・`Makefile`の`check`/`setup`/`up`等の既存target・`.github/workflows/test.yaml`の既存`test`ジョブは変更していない。
- 実際に`make check`（PHP 8.2.30、検証専用Compose project `holidays-webhook-server-check`）を実行し、変更前と同じ内容（`composer:validate`→`composer:audit`(44件baseline)→`composer:prod-check`→Pint→PHPStan→PHPUnit 65 passed）で成功（exit 0）することを確認した。

## 必要なPHP拡張

`docker/web/Dockerfile`が導入する拡張（`pdo_mysql`・`intl`・`gd`・`zip`・xdebug）は、PHP 8.5.9でもビルド時にエラーなくインストールでき、`php -m`で全て読み込まれていることを確認した。xdebugは`pecl install xdebug`で`3.5.3`が導入される（PHP 8.5向けの互換バージョンが自動的に選択された）。

## Composer platform設定の確認結果

`composer.json`に`config.platform`（`php`等）の明示的なoverrideは存在しない。`composer.lock`の`platform`／`platform-overrides`もrequire制約の反映のみで、特定のPHPバージョンに固定する設定は無い。したがって、PHP 8.5での検証結果は実行時の実PHPバージョンをそのまま反映したものであり、platform設定によって覆い隠されている問題はない。

## PHP 8.5で成功した検証

隔離したDocker環境（後述）で、PHP 8.5.9に対して次が成功することを確認した。

- Dockerイメージのビルド（`docker/web/Dockerfile`をビルド引数だけ変更）
- 必要拡張（`pdo_mysql`・`intl`・`gd`・`zip`）の読み込み確認
- `php --version`（8.5.9）・`composer --version`（2.8.12、Composer自体はPHP 8.5.9上で問題なく動作）
- `composer validate --strict`（`vendor`不要、composer.json/lockの整合性のみ検証。`php85-compat-check.php`内でも既知判定より前に必ず実行し、成功することを確認している）
- `composer:audit`（`scripts/audit-guard.php`監査ラッパー経由）を単体で実行した場合も、`vendor`不要でcomposer.lockを直接監査するためPHPバージョン互換性とは独立に成功し、44件のbaselineをそのまま検知することを確認した。ただし`make check-php85`の現在のフロー（`composer install`が既知の非互換で止まる状態）では、`composer:audit`は`composer install`成功後の`composer check`の一部としてしか実行されないため、今回のPRでは**実行されていない**（後述の「PHP 8.5で失敗・警告となった検証」を参照）。

## PHP 8.5で失敗・警告となった検証

- **`composer check-platform-reqs`**: `php 8.5.9 nette/schema requires php ([>= 8.1.0.0-dev < 8.5.0.0-dev]) nette/schema requires php (8.1 - 8.4) failed` の1件のみが失敗（他のext-*要件は全て`success`）。
- **`composer install --no-interaction --prefer-dist`**（`make check-php85`の中で最初に失敗する処理）:

  ```
  Problem 1
    - nette/schema is locked to version v1.3.2 and an update of this package was not requested.
    - nette/schema v1.3.2 requires php 8.1 - 8.4 -> your php version (8.5.9) does not satisfy that requirement.
  Problem 2
    - nette/utils is locked to version v4.0.5 and an update of this package was not requested.
    - nette/utils v4.0.5 requires php 8.0 - 8.4 -> your php version (8.5.9) does not satisfy that requirement.
  Problem 3
    - league/config is locked to version v1.2.0 and an update of this package was not requested.
    - league/config v1.2.0 requires nette/schema ^1.2 -> satisfiable by nette/schema[v1.3.2].
    - nette/schema v1.3.2 requires php 8.1 - 8.4 -> your php version (8.5.9) does not satisfy that requirement.
  ```

  依存関係インストールがこの時点で失敗するため、`make check-php85`の以降のステップ（`web`/`db`コンテナの起動、`php artisan db:seed`、`composer check`＝`composer:prod-check`・Pint・PHPStan/Larastan・PHPUnit）は到達できず、未検証のままである。本プロジェクトはLaravelのmigrationではなく`docker/db/sql`でスキーマを管理しているため（`src/database/migrations`は空）、`php artisan migrate`自体の起動確認もこの依存関係インストール失敗により実施できていない。この状態は下記の「レビュー対応」の節で説明する仕組みにより、Issue #216で追跡している既知の状態として扱い、`php85-compat`ジョブ自体は成功として終える。

## レビュー対応: 既知の非互換を期待結果として厳密に判定する

最初のレビューで、「`php85-compat`を`test`の`needs`から外しても、GitHub Actionsは1つでも失敗したジョブがあればワークフロー全体を失敗として扱うため、non-blockingになっていない」という指摘を受けた。ジョブを独立させることと、ジョブ自体をnon-blockingにすることは別問題であるため、修正した。

続く2回目のレビューで、「既知条件の比較対象がパッケージ名・バージョンだけでPHP制約の内容を見ていない」「`composer install`の別エラー（Composer設定・lock不整合、`composer why-not`自体の異常）が既知のPHP非互換と併存した場合に誤って成功扱いになり得る」という指摘を受け、さらに次のとおり判定を厳密化した。

### 採用した判定方式

`src/scripts/php85-compat-check.php`を追加した。このスクリプトは次を行う。

1. 実行中のPHPが想定どおり`8.5.9`であることを確認する（`PHP_VERSION`定数）。
2. **既知判定より先に`composer validate --strict`を実行する。** ここが失敗した場合は、Composer設定・composer.lockの不整合であり既知のPHP 8.5非互換(Issue #216)とは無関係の問題として、常に終了コード1（未知の失敗）で終える。
3. `composer install --no-interaction --prefer-dist`を実行し、標準出力・標準エラー・終了コードを個別に取得する。
4. 成功（exit 0）した場合は、そのまま終了コード0を返す。呼び出し側（`make check-php85`）はこれを「通常どおり後続を実行してよい」と解釈し、`web`/`db`起動・DB seed・`composer check-platform-reqs`・`composer check`（`composer:validate`→`composer:audit`→`composer:prod-check`→Pint→PHPStan/Larastan→PHPUnit）まで従来どおり実行する。
5. 失敗した場合、`composer why-not php <実行中のPHPバージョン> --locked`（Composer 2.8.12の実コマンド。`--locked`により`vendor`が無くても`composer.lock`だけを根拠に判定できる）を実行する。
   - **`why-not`自体の終了コードが1（＝競合ありの状態）であることを確認する。** それ以外（0＝競合なし、その他）は、既知のPHP制約以外の理由で`composer install`が失敗した可能性があるとして、未知の失敗として終了コード1にする。
   - **`why-not`の標準エラーが想定どおりの1行（`Package "php <version>" found in version "<version>".`）だけであることを厳密に一致確認する。** 余計な内容（警告・別のComposerエラー等）が混ざっていれば、既知のPHP制約と別の問題が併存している可能性があるとして未知の失敗にする。
   - 標準出力は「競合しているパッケージ名・ロック済みバージョン・PHP制約」が1行ずつ構造化された形で列挙される（例: `nette/schema v1.3.2 requires php (8.1 - 8.4)`）。単純な終了コードやエラー文言のgrepではなく、この行を正規表現で解析して `{パッケージ名: {バージョン, PHP制約}}` の集合を得る。
6. 得られた集合が、このスクリプトにハードコードされた既知リスト（`nette/schema => {version: v1.3.2, phpConstraint: "8.1 - 8.4"}`、`nette/utils => {version: v4.0.5, phpConstraint: "8.0 - 8.4"}`。Issue #216で追跡中）と、**パッケージ名・バージョン・PHP制約の3要素すべてで完全一致**する場合だけ、既知の非互換として終了コード2を返す。パッケージ・バージョンが同じでもPHP制約の内容が変化していれば一致しない。
7. それ以外（`why-not`の終了コード・標準エラーが想定外、集合が3要素のいずれかで一致しない、`why-not`の出力を解析できない等）は、想定外の失敗として終了コード1を返す。

`make check-php85`はこの終了コードを見て分岐する。

- `0`: 従来どおり後続（bootstrap・DB seed・静的解析・テスト）を実行する。
- `2`: 「Issue #216で追跡中の既知のPHP 8.5非互換だけを検出したため、bootstrap以降は未実施のまま成功として終了します」とログへ出力し、**`make check-php85`自体は終了コード0（成功）** で終える。
- それ以外: `make check-php85`は終了コード1（失敗）で終える。

`continue-on-error`や、エラー文言の単純な部分一致・全文grepには依存していない。既知リストが更新されない限り（依存パッケージがPHP 8.5対応版へ更新された場合や、PHP制約の内容が変わった場合、想定外の非互換が新たに増えた場合、Composer設定・lockが壊れた場合、`why-not`自体が異常終了した場合）、判定は自動的に「未知の失敗」側に倒れて`make check-php85`ごと失敗するため、既知の状態のまま黙って固定化されたり、別の問題を見逃したりすることはない。

### GitHub Actions側の表示

`php85-compat`ジョブでは、`make check-php85`の出力を`php85-check.log`として保存しつつ、続く「PHP 8.5 compatibility summary」ステップ（`if: always()`）がそのログから状態を判定し、GitHub Step SummaryへPHP 8.5環境構築の成否・必要拡張確認結果・依存関係インストールの完了有無・検出した既知の阻害パッケージ・未実施項目（bootstrap・静的解析・テスト）を明示する。未知の失敗を検出した場合は、その旨をSummaryへ表示したうえで、`make check-php85`自体の失敗によりジョブも失敗する。

### 検証結果

隔離したPHP 8.5専用Compose project（`holidays-webhook-server-check-php85`）だけを使い、次を確認した。

| ケース | 期待結果 | 実際の結果 |
| --- | --- | --- |
| 現状（既知の2パッケージ・バージョン・PHP制約が完全一致） | `php85-compat-check.php`がexit 2、`make check-php85`はexit 0（成功） | 確認済み。`composer validate --strict`成功のログに続き「Issue #216で追跡中の既知のPHP 8.5非互換だけを検出しました」「未実施です」の両方を表示 |
| 上記でもbootstrap・静的解析・テストは未実施であることが明示される | ログ・GitHub Step Summaryの両方に明示 | 確認済み |
| 既知リストのPHP制約の内容（例: `nette/utils`の期待制約を`8.0 - 8.9`に変える）を意図的に変える | パッケージ名・バージョンが同じでも未知の失敗としてexit 1 | 確認済み。「検出された競合」と「既知として登録されている競合」のJSON差分をログへ出力したうえで失敗 |
| `composer.json`を構文的に壊す | 既知判定に進まず、`composer validate --strict`の時点でexit 1 | 確認済み。「Composer設定・composer.lockの不整合であり、既知のPHP 8.5非互換(Issue #216)とは無関係の問題です」と表示して失敗 |
| `composer why-not`に存在しないオプションを渡し、想定外の標準エラーを発生させる | 未知の失敗としてexit 1 | 確認済み。「既知のPHP制約以外のComposerエラーが併存している可能性がある」として失敗 |
| `nette/schema`・`nette/utils`をPHP 8.5対応版へ更新したlockで、ネットワークを遮断して別理由（ダウンロード失敗）でinstallを失敗させる | 未知の失敗としてexit 1 | 確認済み。`composer why-not`が競合なし（exit 0）と報告するため「想定外の終了コード」として失敗 |
| 同じくPHP 8.5対応版へ更新したlockで、ネットワークありでinstallを実行 | `composer install`が成功し、exit 0 | 確認済み（別の隔離コピーで`composer update nette/schema nette/utils --with-dependencies`を実際に適用し、131パッケージすべてがインストールされることを確認。本PRの`composer.json`/`composer.lock`はこの検証のためだけに使い、コミットはしていない） |
| PHP 8.2.30の既存`make check` | 変化なく成功 | 確認済み（65 tests passed、exit 0） |

修正後のPR自体のGitHub Actions（[run 31075956101](https://github.com/bvlion/holidays-webhook-server/actions/runs/31075956101)）で、`php85-compat`ジョブ・`test`ジョブの両方が成功し、ワークフロー全体の結論（conclusion）も`success`になることを確認した。内訳: `php85-compat-check.php`はexit 2（既知の非互換を検出）→ `make check-php85`はこれを期待状態として処理しexit 0（成功）→ GitHub Actionsの`php85-compat`ジョブはsuccess → ワークフロー全体もsuccess、という一連の流れをログで確認済み。

## アプリケーション側と依存側の分類

今回検出した唯一の失敗は**依存パッケージ側**である。アプリケーションコード（`app/`・`routes/`・`tests/`等）に起因する問題は見つかっていない（そもそも`composer install`で止まるため、アプリケーションコードはまだ実行段階に到達していない）。

- 原因: `league/commonmark`（Laravelが利用）→`league/config`経由の間接依存である`nette/schema`（ロック済み`v1.3.2`）・`nette/utils`（ロック済み`v4.0.5`）が、明示的に`php 8.1 - 8.4`／`php 8.0 - 8.4`までしかサポートを宣言していない。
- 確認済みの解決策: Packagist上で`nette/schema v1.3.5`（`php 8.1 - 8.5`）・`nette/utils v4.0.10`（`php 8.0 - 8.5`）／`v4.1.5`（`php 8.2 - 8.5`）という、PHP 8.5をサポートする新しいタグ付きリリースが既に存在することを確認した。隔離コピー上で`composer update nette/schema nette/utils --with-dependencies --dry-run`を実行し、この2パッケージだけの更新で依存解決全体が通ること、`laravel/framework`・`guzzlehttp/guzzle`・`phpunit/phpunit`等の主要パッケージには一切影響しないことも確認済み。
- 本Issueのスコープ（「PHP 8.5で動作させるための無理な依存関係更新は行わない」）に従い、この更新は本PRでは適用していない。

## CIジョブをblockingまたはnon-blockingにした理由

**「既知の非互換だけを期待結果として厳密に検査するテスト」として扱い、ジョブ自体は現状で成功する（=non-blocking）構成にした。** ただし、これは「ジョブを`test`の`needs`から外した」ことによるものではない（GitHub Actionsはジョブを1つでも失敗させればワークフロー全体を失敗として扱うため、`needs`から外すだけではnon-blockingにならないという初回レビューの指摘のとおり）。

- `php85-compat`ジョブは、前述の`php85-compat-check.php`による判定で「Issue #216の既知の非互換だけ」であることを確認できた場合に限り、`make check-php85`自体がexit 0で終わるように設計した。これにより、ジョブの実際の成否（GitHub Actionsのconclusion）が正しく`success`になり、ワークフロー全体・`notify`（Slack通知）にも波及しない。
- 未知の失敗（想定外の非互換、ネットワーク障害、Composer設定不整合、Docker障害等）では`make check-php85`がexit 1で終わり、ジョブ・ワークフロー全体が正しく`failure`になる。`continue-on-error`は使用していない。
- `php85-compat`ジョブは引き続き`test`・`publish-test-report`・`notify`の`needs`には含めていない（PHP 8.2.30側の検証結果とは独立に結果を確認できるようにするため）が、これは「失敗を隠すための独立化」ではなく、単に無関係な2つの検証を1つのジョブに混在させない構成上の理由である。
- 依存関係（`nette/schema`・`nette/utils`）がPHP 8.5対応版へ更新されれば、`composer install`が成功して以降のbootstrap・静的解析・テストまで自動的に実行されるようになる。その時点で新たな失敗が発生すれば、そのときは正しくジョブ・ワークフローが失敗する。

## Issue #216へ持ち越す内容

Issue #216へ次の内容をコメントとして記録した（[コメントへのリンク](https://github.com/bvlion/holidays-webhook-server/issues/216#issuecomment-5199005319)）。

- `composer install`が`nette/schema`・`nette/utils`のPHP上限（8.4）で失敗すること
- 両パッケージのPHP 8.5対応済みバージョン（`nette/schema v1.3.5`・`nette/utils v4.0.10`/`v4.1.5`）と、この2件だけの更新が他の主要パッケージに影響しないことをdry-runで確認済みであること
- Laravel更新作業時にそのまま使える検証環境として`make check-php85`が存在すること

## このPRで行っていないこと

- 本番環境のPHP切り替えは行っていない（本番は引き続きPHP 8.2.30）。
- Laravel 8から9へのアップグレードは行っていない（Issue #216のスコープ）。
- `nette/schema`・`nette/utils`を含め、PHP 8.5で動作させるための依存関係更新は一切行っていない（`composer.json`・`composer.lock`は変更していない）。
- Issue #236で追跡している監査baseline（44件）の解消は行っていない。
- Issue #216以降の実装（Laravel更新本体）には着手していない。

## Docker操作に関する安全策

既存の開発用Composeプロジェクト（`holidays-webhook-server`）・検証用Composeプロジェクト（`holidays-webhook-server-check`）には一切触れていない。すべてのローカルDocker検証は、この作業専用の新しいCompose project名（`holidays-webhook-server-check-php85`、および調査段階の使い捨てイメージ`hw-web-*-test`系）で行い、host portは公開せず、named volumeも作成しない構成にした。作業後、`docker compose -p holidays-webhook-server-check-php85 ps -a`・`docker network ls`・`docker volume ls`でこのprojectに関連するcontainer・network・volumeが残っていないことを確認済み（ビルドした`holidays-webhook-server-check-php85-*`イメージ自体は、既存の`make check`が作る`holidays-webhook-server-check-*`イメージと同様にローカルのビルドキャッシュとして残る。containerではないため開発環境への影響はない）。

## 実行したコマンドと結果

- `docker build --build-arg PHP_IMAGE=php:8.5.9-apache docker/web` → 成功。`php -v`（8.5.9）・`composer --version`（2.8.12）・必要拡張の読み込みを確認。
- `docker build docker/web`（引数なし、PHP 8.2.30） → 成功。全レイヤーCACHED（既存イメージと内容が変わっていないことを確認）。`php -v`が8.2.30のままであることも確認。
- `docker compose -f docker-compose.check.yml -f docker-compose.check-php85.yml -p holidays-webhook-server-check-php85 config` → `web`サービスのビルド引数に`PHP_IMAGE: php:8.5.9-apache`が反映され、host portなし・named volumeなしであることを確認。
- `make check-php85`（`src/.env`を一時的に`.env.example`へ差し替えて実行、実行後に元の内容へbyte-for-byte復元）→ `php85-compat-check.php`はexit 2（既知の非互換を検出）、`make check-php85`自体はこれを期待状態として処理しexit 0（成功）。実行後、専用projectのcontainer・network・volumeが残っていないことを確認。
- `make check`（PHP 8.2.30、同様に`.env`を一時退避・復元）→ 成功（exit 0、65 tests passed）。既存の検証結果に変化がないことを確認（2回実施：初回実装時・判定厳密化後の両方で確認）。
- 隔離コピー上での`composer validate --strict`・`php scripts/audit-guard.php`（監査ラッパー）・`composer check-platform-reqs`（`--no-dev`あり／なし）をPHP 8.5.9で実行し、結果を上記のとおり記録。
- 隔離コピー上での`composer update nette/schema nette/utils --with-dependencies --dry-run`→ 依存解決が成功し、更新対象がこの2パッケージのみであることを確認（`composer.lock`は変更していない）。
- `git diff --check`（作業ブランチ全体）→ 指摘なし。
- `git status --short`（作業前後）→ Issue #215に無関係な変更が含まれていないことを確認。
- `php scripts/php85-compat-check.php`単体・`make check-php85`全体を、上記「検証結果」表の7パターンすべてで実行し、期待どおりの終了コード（0/2/1）になることを確認。
- 修正後のPull Request CI（[run 31075956101](https://github.com/bvlion/holidays-webhook-server/actions/runs/31075956101)）で、`php85-compat`ジョブ・`test`ジョブがともに成功し、ワークフロー全体のconclusionが`success`になることを確認。GitHub Step Summaryの内容も想定どおり表示されることを確認。

## 実行できなかった検証と理由

- Laravel bootstrap・migration・`composer:prod-check`・Laravel Pint・PHPStan/Larastan・PHPUnitの、現在の`composer.lock`のままでのPHP 8.5実行確認: 前述のとおり`composer install`が依存側の問題（Issue #216で追跡中）で失敗するため、`vendor`が生成されず到達できていない。この状態は`php85-compat-check.php`が既知の状態として検出し、`php85-compat`ジョブ自体は成功として終える設計にしたが、これらの検証そのものは未実施のままである（GitHub Step Summaryにも明示する）。`nette/schema`・`nette/utils`がPHP 8.5対応版へ更新された時点で、`make check-php85`が自動的にこれらの検証まで実行するようになる。

Closes #215

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


