### PR TITLE
publish-test-reportジョブにactions/checkoutを追加する

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,6 +87,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
       - name: download test report
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## 概要

Issue #241 の対応です。

PR #240 を main へマージした後の GitHub Actions で、`test` と `php85-compat` は成功しましたが、`publish-test-report` が失敗していました。原因は `.github/workflows/test.yaml` の `publish-test-report` ジョブに `actions/checkout` がなく、Git リポジトリが存在しない Runner 上で `JamesIves/github-pages-deploy-action@v4` が Git 設定（`git config user.name` など）を行おうとして失敗していたためです。

## 変更内容

`publish-test-report` ジョブの steps 先頭に `actions/checkout@v4` を追加し、Issue #241 に記載の想定変更のとおり次の順序にしました。

1. `actions/checkout@v4`
2. `actions/download-artifact@v4` で `test-report` を `report` へダウンロード
3. 既存の `JamesIves/github-pages-deploy-action@v4` で `report` を `gh-pages` へ公開

## 変更範囲

Issue で指定された範囲のみを変更しています。以下は変更していません。

- `gh-pages` への公開方式
- テストレポートの生成方法
- artifact の生成・保存方法
- `notify` ジョブの条件・処理
- Pull Request イベントで `publish-test-report` を skip する既存の条件
- Action のメジャーバージョン
- workflow 全体の整理・リファクタリング
- アプリケーションコードや依存関係

なお、Issue #242（Laravel 12 更新）の変更は取り込まず、現在の main を起点に Issue #241 のみを対応しています。

## 検証結果（PR上で確認可能な範囲）

- [x] `actionlint` で workflow の構文に問題がないことを確認済み
- [x] `test` が成功すること（[CI run](https://github.com/bvlion/holidays-webhook-server/actions/runs/31167235199)で確認済み）
- [x] `php85-compat` が成功すること（同上）
- [x] Pull Request イベントでは `publish-test-report` が従来どおり skip されること（同上、`publish-test-report`・`notify` とも `if: github.event_name == 'push'` によりskip）

## 未確認事項（main へのマージ後にのみ確認可能）

- `publish-test-report` が成功すること
- `test-report` artifact が正常にダウンロードされること
- `report` の内容が `gh-pages` へ公開されること
- `notify` が `publish-test-report` の成功を含めて正常終了すること

## その他

- 開発用 Docker コンテナ・network・volume・`src/.env` には影響していません
- Issue #241 は本PRのマージ後に手動でご確認のうえクローズしてください（自動クローズは設定していません）

Refs #241
