### PR TITLE
Dependabot設定とpatch自動マージ方針を整備する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,44 @@
 version: 2
 updates:
+  # Composer (src/composer.json)
   - package-ecosystem: "composer"
     directory: "/src"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "08:00"
       timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    groups:
+      # patchのみをまとめる。auto-mergeワークフローはこのグループのPRを
+      # dependabot/fetch-metadataのupdate-typeで判定するため、
+      # patch以外のupdate-typeを混在させないこと。
+      composer-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+      composer-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+      # majorはグルーピングしない（個別PRのまま、手動確認）。
+
+  # GitHub Actions (.github/workflows/*.yaml)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:30"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    groups:
+      actions-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+      actions-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+      # majorはグルーピングしない（個別PRのまま、手動確認）。

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,36 @@
+name: dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Dependabotが同一リポジトリ内に作成したPRのみを対象にする。
+    # フォークからのPRやDependabot以外の作成者は対象外。
+    if: >
+      github.repository == 'bvlion/holidays-webhook-server' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # semver patchのみauto-mergeを有効化する。
+      # minor/majorはここで弾かれ、手動確認に回る。
+      - name: enable auto-merge for semver patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,73 @@
+# 依存関係更新の運用
+
+## 1. 目的と対象
+
+この文書は、Issue #222 に基づき、Dependabotによる依存関係更新の運用方針を定める。
+
+対象は次のとおりである。
+
+- Composer（`/src`）
+- GitHub Actions（`.github/workflows`）
+
+## 2. 更新頻度とPR上限
+
+- 両エコシステムとも週次（毎週月曜、Asia/Tokyo）で確認する。
+- 過剰なPRを避けるため、`open-pull-requests-limit` をComposer・GitHub Actionsとも10件とする。
+
+## 3. Grouping方針
+
+`.github/dependabot.yml` では、エコシステムごとに次のグループを定義する。
+
+- `composer-patch` / `actions-patch`: `update-types: ["patch"]` のみを含むグループ
+- `composer-minor` / `actions-minor`: `update-types: ["minor"]` のみを含むグループ
+- major更新はグループに含めない（個別PRのまま作成される）
+
+patchグループとminorグループを分離し、majorをどちらとも混在させないことで、後述のauto-mergeワークフローが「そのPRがpatchのみで構成されているか」を安全に判定できるようにしている。
+
+## 4. patch / minor / majorの扱い
+
+| 区分 | PRの単位 | 自動マージ |
+| --- | --- | --- |
+| patch | グループ化（`composer-patch` / `actions-patch`） | する |
+| minor | グループ化（`composer-minor` / `actions-minor`） | しない（手動確認） |
+| major | 個別PR | しない（手動確認・個別対応） |
+
+## 5. patch自動マージの条件
+
+`.github/workflows/dependabot-auto-merge.yaml` が、`dependabot/fetch-metadata` を使い、GitHub公式ドキュメント（[Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions)）の手順に沿って以下をすべて満たす場合だけ `gh pr merge --auto --merge` でauto-mergeを有効化する。
+
+- PR作成者が `dependabot[bot]`（`github.actor` と `pull_request.user.login` の両方で確認）
+- 対象リポジトリが `bvlion/holidays-webhook-server`（フォークからのPRを除外）
+- base branchが `main`
+- `dependabot/fetch-metadata` の `update-type` 出力が `version-update:semver-patch`
+- mainブランチのruleset上で必須の `test` チェックが成功していること（後述）
+
+minor・major、および人間が作成した通常のPRはこの条件に一致しないため自動マージされない。専用のPersonal Access Tokenは追加せず、標準の `GITHUB_TOKEN` のみを使用する。
+
+`gh pr merge --auto` はGitHubの auto-merge 機能を有効化するだけであり、実際のマージは、mainブランチで必須化した `test` ステータスチェックが成功するまで行われない。CIが失敗した場合、auto-mergeは解除され、そのPRは手動確認が必要な状態のまま残る。
+
+## 6. mainブランチの保護（ruleset）
+
+リポジトリruleset「main protection」（`refs/heads/main` 対象、enforcement: active）で次を必須化した。
+
+- `pull_request` ルール: Pull Request経由のマージのみを許可し、直接pushを禁止する（レビュー承認は必須化していない。`required_approving_review_count: 0`）
+- `required_status_checks` ルール: `test` チェックの成功を必須とする
+- `non_fast_forward` ルール: force pushを禁止する
+
+既存の手動PR運用（レビュー承認なしでマージできる運用）は変更していない。
+
+## 7. auto-merge有効化のためのリポジトリ設定
+
+- リポジトリ設定 `allow_auto_merge` を `true` に変更した（変更前: `false`）。
+- マージ方式は既存運用に合わせ、`merge commit` を使用する（`gh pr merge --auto --merge`）。squash・rebaseのリポジトリ設定自体は変更していない。
+- `allow_update_branch` は変更していない（`false` のまま）。mainブランチの `required_status_checks` は `strict_required_status_checks_policy: false` とし、ブランチが最新でなくても、PRのhead commitで `test` が成功していればマージ可能とした。
+
+## 8. Dependabot PRの手動対応方法
+
+- minor・majorのPRは、内容を確認し、CIが成功していることを確認したうえで手動でマージする。
+- CIが失敗したPRは、依存先の変更内容を確認し、必要に応じてコード側を修正するか、Dependabotのリベースを待つ。
+- 古いDependabot PRでmainの現状と矛盾する、または既に不要になったものがあれば、内容を確認したうえで手動でclose/rebaseする（自動では処理しない）。
+
+## 9. 既知の古いDependabot PR
+
+- PR #206（`phpunit/phpunit` を `9.6.22` から `11.5.2` へ更新）は2024-12-22作成のまま残っているが、現在のmain（`src/composer.json`）は既に `phpunit/phpunit: ^12.0` を要求しており、このPRの内容は既に不要である。Issue #222の範囲ではclose/mergeせず、対応要否の判断を運用者に委ねる。

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -44,7 +44,11 @@ patchグループとminorグループを分離し、majorをどちらとも混�
 
 minor・major、および人間が作成した通常のPRはこの条件に一致しないため自動マージされない。専用のPersonal Access Tokenは追加せず、標準の `GITHUB_TOKEN` のみを使用する。
 
-`gh pr merge --auto` はGitHubの auto-merge 機能を有効化するだけであり、実際のマージは、mainブランチで必須化した `test` ステータスチェックが成功するまで行われない。CIが失敗した場合、auto-mergeは解除され、そのPRは手動確認が必要な状態のまま残る。
+`gh pr merge --auto` はGitHubの auto-merge 機能を有効化するだけであり、実際のマージ可否は、mainブランチで必須化した `test` ステータスチェックの結果に従う。
+
+- `test` が成功するまで、実際のマージは行われない。
+- `test` が失敗している状態ではマージされない。
+- その後 `test` を再実行するなどして成功すれば、他の条件（PR作成者、base branch、`update-type` 等）を満たしている限り、有効化されたauto-mergeによって自動的にマージされ得る。auto-merge自体はCI失敗によって解除されるわけではない。
 
 ## 6. mainブランチの保護（ruleset）
 


### PR DESCRIPTION
## 概要

Issue #222の対応。Dependabot設定と、patch更新のみを対象とした安全なauto-merge運用を整備した。minor/majorは自動マージしない。

## Dependabotの最終方針

- 対象: Composer（`/src`）、GitHub Actions（`.github/workflows`）（GitHub Actionsは新規追加）
- 頻度: 週次（毎週月曜、Asia/Tokyo）。PR過多を避けるため`daily`から変更
- `open-pull-requests-limit`: 各エコシステム10件
- grouping: `composer-patch`/`actions-patch`（patchのみ）、`composer-minor`/`actions-minor`（minorのみ）に分離。**majorはグループ化せず個別PR**とし、patch/minor/majorが混在するグループを作らない構成にした

## patch自動マージの安全条件

`.github/workflows/dependabot-auto-merge.yaml`を追加。GitHub公式ドキュメント（[Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions)）の手順に沿い、`dependabot/fetch-metadata`（SHA固定 v3.1.0）で以下をすべて満たす場合のみ`gh pr merge --auto --merge`を実行する。

- PR作成者が`dependabot[bot]`（`github.actor`と`pull_request.user.login`の双方で確認、フォークPRは`github.repository`で除外）
- base branchが`main`
- `update-type`が`version-update:semver-patch`
- mainブランチのruleset上で`test`チェックが成功していること。実際のマージ可否は`test`の結果に従い、
  - `test`が成功するまでマージされない
  - `test`が失敗している状態ではマージされない
  - その後`test`を再実行するなどして成功すれば、他の条件を満たしている限り有効化されたauto-mergeによって自動的にマージされ得る（CI失敗を理由にauto-merge自体が解除されるわけではない）

minor/major、および人間が作成した通常のPRはこの条件に一致せず自動マージされない。専用PATは追加せず、標準の`GITHUB_TOKEN`のみを使用している。

## 変更したリポジトリ設定

- `allow_auto_merge`: `false` → `true`
- mainブランチに repository ruleset「main protection」を新規作成（enforcement: active、旧branch protectionは未設定だったため新設）
  - `pull_request`ルール: PR経由のマージのみ許可、直接push禁止（`required_approving_review_count: 0`でレビュー承認必須化はしていない）
  - `required_status_checks`ルール: `test`チェックの成功を必須化
  - `non_fast_forward`ルール: force push禁止
- `allow_update_branch`は変更していない（`false`のまま）。`strict_required_status_checks_policy: false`とし、ブランチが最新でなくてもhead commitで`test`が成功していればマージできるようにした（既存の手動PR運用を不必要に厳しくしないため）
- merge方式（既存運用の merge commit）は変更していない

詳細はdocs/dependency-updates.mdに記録した。

## `make check`結果

成功。67 tests / 136 assertions（既存件数のまま、スキップ・削除なし）。

```
Tests:    67 passed (136 assertions)
```

`.github/dependabot.yml`・`.github/workflows/dependabot-auto-merge.yaml`はactionlint、YAML parse双方で構文確認済み。

## マージ後に実際のDependabot PRで確認すべきこと

- 次回Dependabot実行（週次）でComposer/GitHub Actionsの新規PRが意図通りgroupingされ、patch PRで`dependabot-auto-merge`ワークフローが起動し`update-type`が正しく判定されること
- patch PRで実際に`test`成功後、auto-mergeによってmerge commitでマージされること
- minor/major PRでauto-mergeが有効化されないこと

## 古いDependabot PR

- **PR #206**（`phpunit/phpunit` 9.6.22→11.5.2、2024-12-22作成）: 現在のmain（`src/composer.json`）は既に`phpunit/phpunit: ^12.0`を要求しており、このPRの内容は既に不要。Issue #222の指示に従い、close/mergeせず対応要否の判断を運用者に委ねる（docs/dependency-updates.mdにも記載）

## 変更していないもの

アプリ本体の仕様、Laravel/PHP/MySQL、認証、scheduler、デプロイ方式、本番環境はいずれも変更していない。

Closes #222

