### PR TITLE
health check・scheduler heartbeat・外部HTTP失敗の安全な扱いを追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALENDAR_API_KEY=
 GOOGLE_CALLBACK_URL=http://localhost:8000/login/callback
+
+# "/health" がscheduler停止とみなすまでの秒数（time:triggerの最終成功から）。
+# 未設定時は300秒（5分）。docs/monitoring.md参照。
+HEALTH_SCHEDULER_HEARTBEAT_THRESHOLD=300

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Pull Requestの作成・更新、mainへのpush、Dependabotが作成するPull 
 | [`docs/domain.md`](docs/domain.md) | コードから読み取れる主要ドメインルール |
 | [`docs/current-architecture.md`](docs/current-architecture.md) | Issue #208時点の詳細な実装棚卸し（現状差異・後続Issue候補を含む） |
 | [`docs/current-operations.md`](docs/current-operations.md) | ローカル・CI・本番の運用詳細と確認状況 |
+| [`docs/monitoring.md`](docs/monitoring.md) | `GET /health`・scheduler heartbeat・外部連携失敗時の確認方法 |
 | [`docs/secrets-management.md`](docs/secrets-management.md) | 秘密情報・個人情報・ログの管理方針 |
 | [`docs/dependency-updates.md`](docs/dependency-updates.md) | Dependabotによる依存関係更新の運用方針 |
 | [`doc/api/`](doc/api) | 一部APIの詳細仕様 |

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -40,6 +40,7 @@ Issue #226でPHP 8.5への本番切り替えを行う際も、このチェック
 ## 主要機能確認
 
 - [ ] 公開URLのルートが200で応答する
+- [ ] `GET /health`が200で応答する（`ng`のcomponentがあれば[`monitoring.md`](monitoring.md) 7節に沿って切り分ける）
 - [ ] 主要APIエンドポイント（コマンド一覧・実行系）が想定どおり応答する
 - [ ] Google認証フロー（`/auth/redirect` → コールバック）が成功する
 - [ ] 休日判定・個別カレンダー上書きが想定どおり動作する
@@ -49,6 +50,7 @@ Issue #226でPHP 8.5への本番切り替えを行う際も、このチェック
 
 - [ ] `holidays:update`・`time:trigger`・`results:delete`を起動するOS側cron／systemd timer等が、デプロイ後も引き続き設定されている（本番の起動方法自体は未確認事項。[`current-operations.md`](current-operations.md) 5.5節）
 - [ ] `time:trigger`が直近で実行され、対象の時間トリガーが処理されていることをログまたは`exec_results`で確認した
+- [ ] `logs/scheduler-heartbeat.json`の`time:trigger`が直近で更新されている（[`monitoring.md`](monitoring.md) 3節・6節）
 - [ ] Schedulerの多重起動が発生していないことを確認した
 
 ## ログ確認

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,139 @@
+# 監視（health check / scheduler heartbeat）
+
+この文書は、Issue #225に基づき、`GET /health` とscheduler heartbeatの仕組み、および外部連携（Google認証・Google Calendar・コマンド実行先）失敗時の確認方法を整理したものである。デプロイ手順は[`deployment.md`](deployment.md)、ロールバック手順は[`rollback.md`](rollback.md)、秘密情報の扱いは[`secrets-management.md`](secrets-management.md)を参照する。
+
+## 1. `GET /health` の意味
+
+`/health`は、`/`（サーバー時刻とDB時刻を返す簡易確認用エンドポイント、Issue #225では仕様変更していない）とは別に用意した、外形監視向けの専用エンドポイントである。次の4点を判定する。
+
+| component | 判定内容 |
+| --- | --- |
+| `app` | Laravelアプリケーションがリクエストに応答できている（このレスポンスが返ること自体が確認） |
+| `database` | `DB::select('SELECT 1')` がDBへ接続して成功する |
+| `config` | 稼働に必須な設定（`APP_KEY`、DB接続情報、Google認証・Google Calendar関連設定）が空でない |
+| `scheduler` | `time:trigger` の最終成功が、後述の閾値以内に記録されている |
+
+認証は不要で、公開経路から到達できることを前提にしている（外形監視ツールから叩く想定）。
+
+## 2. HTTP 200 / 503 の判定
+
+4つのcomponentすべてが`ok`であればHTTP 200、いずれか1つでも`ng`であればHTTP 503を返す。レスポンス例は次のとおり。
+
+```json
+{
+  "status": "ok",
+  "components": {
+    "app": "ok",
+    "database": "ok",
+    "config": "ok",
+    "scheduler": "ok"
+  }
+}
+```
+
+```json
+{
+  "status": "ng",
+  "components": {
+    "app": "ok",
+    "database": "ng",
+    "config": "ok",
+    "scheduler": "ok"
+  }
+}
+```
+
+**公開レスポンスにはcomponent名とok/ngしか含めない。** 次の情報は一切含めない（[`secrets-management.md`](secrets-management.md)の方針と同じ）。
+
+- DB接続情報（ホスト・DB名・ユーザー名・パスワード）
+- ホスト名、filesystemの絶対パス
+- `APP_KEY`、Google Client ID / Secret、Google Calendar APIキー、webhook URL、外部HTTP URL、token
+- 例外メッセージ、stack trace
+
+どのcomponentが`ng`だったかという事実（component名）だけがレスポンスに現れる。**具体的な原因（どの設定が欠けているか、DBの何が失敗したか等）はレスポンスへ含めず、ログ（3節）でのみ確認できるようにしている。**
+
+## 3. scheduler heartbeatの仕組み
+
+DB schemaやLaravel migrationを新設せず、本番deployで`logs/`が保持される現在の構成（[`deployment.md`](deployment.md) 2節）を使う。
+
+- `time:trigger`・`results:delete`・`holidays:update`の各Artisanコマンドは、`handle()`内で処理全体を`try/catch`し、成功時・失敗時に`App\Libs\SchedulerHeartbeat`経由で`logs/scheduler-heartbeat.json`へ最終成功・失敗時刻を書き込む。
+- 時刻はUTCのISO8601形式（例: `2026-08-08T03:00:00+00:00`）で保存し、タイムゾーンに依存した比較ミスを避ける。読み取り側は保存された時刻とオフセットからCarbonで比較する。
+- 書き込みは一時ファイルへ書いてから`rename()`する atomic write とし、読み込み途中で壊れた内容を見ることを避ける。同時書き込みは`logs/scheduler-heartbeat.json.lock`に対する`flock()`で排他する。
+- `time:trigger`の成功は「その回のscheduler実行が完了したこと」を表す。個々のトリガーの外部HTTP呼び出しが失敗しても（4節）、`time:trigger`コマンド自体は例外を投げずに完了するため、heartbeatは更新され続ける。heartbeatはあくまで「schedulerが動いているか」を見るものであり、「すべての外部連携が成功しているか」は見ていない。
+- `results:delete`・`holidays:update`についても同じ仕組みで最終成功・失敗時刻を記録する。ただし`/health`が異常と判定する対象は`time:trigger`だけである（次節）。
+
+## 4. heartbeatが古いと異常と判断する基準
+
+`/health`の`scheduler`componentは、`time:trigger`の最終成功時刻が現在時刻から`HEALTH_SCHEDULER_HEARTBEAT_THRESHOLD`秒（既定300秒 = 5分、`.env.example`参照）以内でなければ`ng`とする。
+
+- `time:trigger`は毎分実行される想定だが、本番でLaravel Schedulerを起動するOS側cronの実際の間隔はリポジトリから確認できない（[`current-operations.md`](current-operations.md) 5.5節）。想定間隔(1分)より十分余裕を持たせた既定値とし、実際の運用間隔に応じて`.env`の`HEALTH_SCHEDULER_HEARTBEAT_THRESHOLD`を調整すること。
+- `results:delete`（毎時）・`holidays:update`（毎月）は`/health`の判定対象に含めない。月次ジョブが毎日実行されていないことを異常として扱うと誤検知になるため、これらの最終成功・失敗はheartbeatファイルを直接確認する運用とする（5節）。
+- heartbeatファイルが存在しない場合（初回deploy直後、`logs/`が新しい環境等）も`ng`として扱う。
+
+## 5. 外部連携失敗の確認方法
+
+`/health`はGoogleへ実通信して確認しない（設定の存在確認と実際の利用時のエラー記録を分離している）。外部連携（Google認証・Google Calendar・コマンド実行先への手動/時間トリガー実行）の失敗は、すべてLaravelの通常ログ（`logs/laravel.log`）へ記録される。
+
+| 失敗箇所 | ログのイベント名 | 記録される内容 |
+| --- | --- | --- |
+| 手動コマンド実行（`CommandExecController`）でレスポンスを伴わない失敗 | `external_http.no_response` | `integration=command_exec`、`command_id`、例外クラス名 |
+| `time:trigger`でレスポンスを伴わない失敗 | `external_http.no_response` | `integration=time_trigger`、`trigger_id`、例外クラス名 |
+| `time:trigger`内のGoogle Calendar祝日判定失敗 | `time_trigger.holiday_lookup_failed` | `trigger_id`、例外クラス名（該当トリガーだけスキップし、他のトリガーの実行は継続する） |
+| Google Calendar API取得失敗（`HolidayList`） | `external_service.failure` | `integration=google_calendar`、例外クラス名、（分かる場合のみ）HTTPステータス |
+| Google認証失敗（`GoogleLoginController`） | `external_service.failure` | `integration=google_auth`、`operation`（`callback` / `api_login`）、例外クラス名 |
+| `/health`のDB接続失敗 | `health_check.database_failure` | 例外クラス名 |
+| `/health`の必須設定欠落 | `health_check.config_missing` | 欠落した設定「名」の一覧（実値は含まない） |
+| `/health`のscheduler停止 | `health_check.scheduler_stale` | 対象タスク名、閾値秒数 |
+
+**ログにはaccess token・authorization code・client secret・callback query・外部URL・Authorizationヘッダー・リクエストbody・例外の生メッセージを出力しない。** 例外の生メッセージ（`getMessage()`）は、Google Calendar APIのようにURLへAPIキーを含める実装ではリクエストURL全体を含み得るため、意図的にログへも例外オブジェクトの`$previous`へも含めていない。安全に取得できる情報（例外クラス名、必要ならHTTPステータスコード）だけを記録する。
+
+## 6. ログ確認方法
+
+ローカル・本番とも`logs/laravel.log`を確認する（[`current-operations.md`](current-operations.md) 5.6節）。本番は`.github/workflows/deploy.yaml`のdeploy処理が`logs`ディレクトリを配備先で保持するため、deployをまたいでログが残る（[`deployment.md`](deployment.md) 2節）。
+
+scheduler heartbeatの生データは`logs/scheduler-heartbeat.json`を直接確認する。例:
+
+```json
+{
+  "time:trigger": {"status": "success", "last_success_at": "2026-08-08T03:00:00+00:00"},
+  "results:delete": {"status": "success", "last_success_at": "2026-08-08T02:00:00+00:00"},
+  "holidays:update": {"status": "success", "last_success_at": "2026-08-01T00:00:00+00:00"}
+}
+```
+
+`status`が`failure`の場合は`last_failure_at`が最終失敗時刻を表す。失敗は`last_success_at`を更新しない。
+
+## 7. health異常時の一次切り分け
+
+1. `/health`のレスポンスで、どのcomponentが`ng`かを確認する。
+2. `database`が`ng`の場合: `logs/laravel.log`の`health_check.database_failure`を確認し、DB自体の疎通（[`current-operations.md`](current-operations.md) 5.4節相当の確認）を行う。DBスキーマ不一致が疑われる場合は[`rollback.md`](rollback.md) 6節を参照する。
+3. `config`が`ng`の場合: `logs/laravel.log`の`health_check.config_missing`で欠落した設定「名」を確認し、本番`.env`の該当項目を人間が確認する（実値はログに出ないため、AIエージェントは実値を扱わない）。
+4. `scheduler`が`ng`の場合は8節を参照する。
+5. 直近のdeploy（tag push）が原因と疑われる場合は[`rollback.md`](rollback.md)の判断フローに従う。
+
+## 8. scheduler停止時に人間が確認する内容
+
+`/health`の`scheduler`が`ng`、または`logs/scheduler-heartbeat.json`の`time:trigger`が更新されていない場合、原因はアプリケーションコードではなく実行基盤側にあることが多い。次を人間が確認する（[`current-operations.md`](current-operations.md) 8節の未確認事項に対応）。
+
+1. 本番でLaravel Schedulerを起動しているcron／systemd timer等の定義が存在し、有効になっているか。
+2. 直近の`time:trigger`実行がcron側のログ・OSのジョブ履歴に残っているか。
+3. `php artisan schedule:run`実行時のPHPエラー（拡張不足、`.env`不備等）がないか。
+4. DB接続失敗など、`time:trigger`自体が例外で終了する原因がないか（`logs/laravel.log`を確認）。
+5. 同一時刻の多重起動やサーバー間の時刻ずれがないか。
+
+## 9. Google / 外部HTTP障害時の切り分け
+
+- Google認証（`/auth/redirect`、`/login/callback`）が失敗する場合は、[`rollback.md`](rollback.md)の「Google連携が失敗する」行の観点（Google側の一時障害か、コード・設定変更起因か）に加え、`logs/laravel.log`の`external_service.failure`（`integration=google_auth`）でoperationと例外クラス名を確認する。
+- Google Calendar取得（休日判定）が失敗する場合は、同ログの`integration=google_calendar`を確認する。`time:trigger`経由の場合は個別トリガーだけがスキップされるため、`time_trigger.holiday_lookup_failed`で対象トリガーを特定できる。
+- コマンド実行先（手動実行・`time:trigger`）でレスポンスを伴わない失敗（DNS失敗・connect timeout・connection refused等）は、`external_http.no_response`で確認する。この場合、`exec_results`（`time:trigger`経由のみ）には`response_code=0`、`response_header`・`response_body`に`{"error":"no_response",...}`という固定表現で保存され、実際のHTTPレスポンスと区別できる。手動実行のAPIレスポンスも同じ表現を返す。
+- HTTP 4xx/5xxのようにレスポンスを伴う失敗は、従来どおり実際のステータスコードが`exec_results`・APIレスポンスへ反映される（変更なし）。
+
+## 10. Slack通知について
+
+このIssueではSlack通知を**採用していない**。理由は次のとおり。
+
+- 本番でアプリケーションruntime用のSlack webhook（`LOG_SLACK_WEBHOOK_URL`）が設定済みかどうかはリポジトリから確認できない。
+- GitHub Actions用の`SLACK_WEBHOOK_URL`（[`secrets-management.md`](secrets-management.md) 4節）はテスト・デプロイ結果通知専用であり、アプリケーションruntimeとは別物のため流用しない。
+- 外部HTTP失敗1件ごとに通知する実装は、障害時に大量通知を発生させるリスクがある。
+
+現状は、本文書の3節〜9節のとおり、`/health`とLaravelの通常ログで異常を検知・追跡できる状態を最低限の要件として満たしている。将来的にSlack通知を追加する場合は、`LOG_SLACK_WEBHOOK_URL`が設定されている場合だけ有効になるoptionalな仕組みとし、同一障害の連続通知を避ける仕組み（例: 一定時間内の重複抑制）を必ず設けること。

--- a/src/app/Console/Commands/DeleteOldExecResultCommand.php
+++ b/src/app/Console/Commands/DeleteOldExecResultCommand.php
@@ -2,8 +2,10 @@
 
 namespace App\Console\Commands;
 
+use App\Libs\SchedulerHeartbeat;
 use App\Models\ExecResult;
 use Illuminate\Console\Command;
+use Throwable;
 
 class DeleteOldExecResultCommand extends Command
 {
@@ -31,6 +33,8 @@ class DeleteOldExecResultCommand extends Command
         parent::__construct();
     }
 
+    private const HEARTBEAT_TASK = 'results:delete';
+
     /**
      * Execute the console command.
      *
@@ -38,25 +42,34 @@ class DeleteOldExecResultCommand extends Command
      */
     public function handle()
     {
-        $results = ExecResult::orderBy('id', 'desc')->get();
-        $hold = []; // command_id をキーにした保持対象
-        $delete = []; // 削除対象 ID 配列
-        foreach ($results as $result) {
-            // キーがなければ新規追加
-            if (! array_key_exists($result->command_id, $hold)) {
-                $hold[$result->command_id] = [$result];
+        $heartbeat = app(SchedulerHeartbeat::class);
 
-                continue;
-            }
-            // 100件未満なら保持対象に追加
-            if (count($hold[$result->command_id]) < 100) {
-                array_push($hold[$result->command_id], $result);
+        try {
+            $results = ExecResult::orderBy('id', 'desc')->get();
+            $hold = []; // command_id をキーにした保持対象
+            $delete = []; // 削除対象 ID 配列
+            foreach ($results as $result) {
+                // キーがなければ新規追加
+                if (! array_key_exists($result->command_id, $hold)) {
+                    $hold[$result->command_id] = [$result];
 
-                continue;
+                    continue;
+                }
+                // 100件未満なら保持対象に追加
+                if (count($hold[$result->command_id]) < 100) {
+                    array_push($hold[$result->command_id], $result);
+
+                    continue;
+                }
+                // 削除対象に追加
+                array_push($delete, $result->id);
             }
-            // 削除対象に追加
-            array_push($delete, $result->id);
+            ExecResult::whereIn('id', $delete)->delete();
+            $heartbeat->recordSuccess(self::HEARTBEAT_TASK);
+        } catch (Throwable $e) {
+            $heartbeat->recordFailure(self::HEARTBEAT_TASK);
+
+            throw $e;
         }
-        ExecResult::whereIn('id', $delete)->delete();
     }
 }

--- a/src/app/Console/Commands/TimeTrigger.php
+++ b/src/app/Console/Commands/TimeTrigger.php
@@ -2,15 +2,21 @@
 
 namespace App\Console\Commands;
 
+use App\Exceptions\HolidayFetchException;
+use App\Libs\ExternalHttpFailure;
+use App\Libs\SchedulerHeartbeat;
 use App\Models\ExecResult;
 use App\Models\OnetimeSkip;
 use App\Models\User;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
 class TimeTrigger extends Command
 {
@@ -39,11 +45,30 @@ class TimeTrigger extends Command
     }
 
     /**
+     * scheduler heartbeat上でこのコマンドを識別する名前。
+     */
+    private const HEARTBEAT_TASK = 'time:trigger';
+
+    /**
      * Execute the console command.
      *
      * @return int
      */
     public function handle()
+    {
+        $heartbeat = app(SchedulerHeartbeat::class);
+
+        try {
+            $this->runTriggers();
+            $heartbeat->recordSuccess(self::HEARTBEAT_TASK);
+        } catch (Throwable $e) {
+            $heartbeat->recordFailure(self::HEARTBEAT_TASK);
+
+            throw $e;
+        }
+    }
+
+    private function runTriggers(): void
     {
         // 実行対象を取得
         $triggers = DB::select("
@@ -129,8 +154,18 @@ class TimeTrigger extends Command
                     continue;
                 }
 
-                // 祝日判定
-                $is_holiday = array_key_exists(date('Y-m-d'), app()->make('HolidayList')->getHolidays($trigger->country_code, date('Y')));
+                // 祝日判定。Google Calendar側の失敗はこのトリガーだけをスキップし、
+                // 他のトリガーの実行やscheduler自体の成功判定には影響させない。
+                try {
+                    $is_holiday = array_key_exists(date('Y-m-d'), app()->make('HolidayList')->getHolidays($trigger->country_code, date('Y')));
+                } catch (HolidayFetchException $e) {
+                    Log::warning('time_trigger.holiday_lookup_failed', [
+                        'trigger_id' => $trigger->t_id,
+                        'exception' => get_class($e),
+                    ]);
+
+                    continue;
+                }
 
                 // 個人カレンダーがあった場合はそちらを優先する
                 if ($trigger->user_holiday !== null) {
@@ -173,8 +208,16 @@ class TimeTrigger extends Command
                             $this->saveResult($trigger, $res);
                         },
                         // Rejected
-                        function (RequestException $e) use ($trigger) {
-                            $this->saveResult($trigger, $e->getResponse());
+                        function (GuzzleException $e) use ($trigger) {
+                            if (ExternalHttpFailure::hasResponse($e)) {
+                                /** @var RequestException $e */
+                                $this->saveResult($trigger, $e->getResponse());
+
+                                return;
+                            }
+
+                            ExternalHttpFailure::log('time_trigger', $e, ['trigger_id' => $trigger->t_id]);
+                            $this->saveNoResponseResult($trigger, $e);
                         }
                     );
 
@@ -186,6 +229,20 @@ class TimeTrigger extends Command
         $pool = new Pool($client, $requests());
         $promise = $pool->promise();
         $promise->wait();
+    }
+
+    private function saveNoResponseResult($trigger, GuzzleException $e)
+    {
+        $payload = ExternalHttpFailure::noResponsePayload($e);
+
+        ExecResult::create([
+            'command_id' => $trigger->c_id,
+            'trigger_id' => $trigger->t_id,
+            'exec_time' => $trigger->exec_time,
+            'response_code' => $payload['response_code'],
+            'response_header' => $payload['response_header'],
+            'response_body' => $payload['response_body'],
+        ]);
     }
 
     private function saveResult($trigger, ResponseInterface $res)

--- a/src/app/Console/Commands/UpdateHolidayCache.php
+++ b/src/app/Console/Commands/UpdateHolidayCache.php
@@ -2,7 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Libs\SchedulerHeartbeat;
 use Illuminate\Console\Command;
+use Throwable;
 
 class UpdateHolidayCache extends Command
 {
@@ -30,6 +32,8 @@ class UpdateHolidayCache extends Command
         parent::__construct();
     }
 
+    private const HEARTBEAT_TASK = 'holidays:update';
+
     /**
      * Execute the console command.
      *
@@ -37,9 +41,18 @@ class UpdateHolidayCache extends Command
      */
     public function handle()
     {
-        app()->make('HolidayList')->clear();
-        // 日本だけキャッシュしておく
-        app()->make('HolidayList')->getHolidays('jp', date('Y'));
-        app()->make('HolidayList')->getHolidays('jp', date('Y') + 1);
+        $heartbeat = app(SchedulerHeartbeat::class);
+
+        try {
+            app()->make('HolidayList')->clear();
+            // 日本だけキャッシュしておく
+            app()->make('HolidayList')->getHolidays('jp', date('Y'));
+            app()->make('HolidayList')->getHolidays('jp', date('Y') + 1);
+            $heartbeat->recordSuccess(self::HEARTBEAT_TASK);
+        } catch (Throwable $e) {
+            $heartbeat->recordFailure(self::HEARTBEAT_TASK);
+
+            throw $e;
+        }
     }
 }

--- a/src/app/Exceptions/HolidayFetchException.php
+++ b/src/app/Exceptions/HolidayFetchException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Google Calendar APIからの祝日取得に失敗したことを表す。
+ *
+ * 元のGuzzle例外のメッセージにはAPIキーを含むリクエストURLが含まれ得るため、
+ * 意図的に元例外を $previous として保持せず、安全な固定メッセージだけを持つ。
+ */
+class HolidayFetchException extends RuntimeException {}

--- a/src/app/Http/Controllers/Api/CommandExecController.php
+++ b/src/app/Http/Controllers/Api/CommandExecController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Libs\ExternalHttpFailure;
 use App\Models\Command;
 use App\Models\SummarizeCommand;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\Request;
 use Psr\Http\Message\ResponseInterface;
@@ -79,8 +81,16 @@ class CommandExecController extends BaseApiController
             try {
                 $res = $client->request($command->method, $command->url, $options);
                 array_push($results, $this->saveResult($command->target_name, $res));
-            } catch (RequestException $e) {
-                array_push($results, $this->saveResult($command->target_name, $e->getResponse()));
+            } catch (GuzzleException $e) {
+                if (ExternalHttpFailure::hasResponse($e)) {
+                    /** @var RequestException $e */
+                    array_push($results, $this->saveResult($command->target_name, $e->getResponse()));
+
+                    continue;
+                }
+
+                ExternalHttpFailure::log('command_exec', $e, ['command_id' => $command->id]);
+                array_push($results, $this->saveNoResponseResult($command->target_name, $e));
             }
         }
 
@@ -95,5 +105,10 @@ class CommandExecController extends BaseApiController
             'response_header' => json_encode($res->getHeaders(), true),
             'response_body' => $res->getBody(),
         ];
+    }
+
+    private function saveNoResponseResult(string $name, GuzzleException $e)
+    {
+        return array_merge(['name' => $name], ExternalHttpFailure::noResponsePayload($e));
     }
 }

--- a/src/app/Http/Controllers/Web/GoogleLoginController.php
+++ b/src/app/Http/Controllers/Web/GoogleLoginController.php
@@ -6,9 +6,12 @@ use App\Http\Controllers\Controller;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as GoogleUser;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
 
 class GoogleLoginController extends Controller
 {
@@ -19,7 +22,14 @@ class GoogleLoginController extends Controller
 
     public function authGoogleCallback()
     {
-        $google = Socialite::driver('google')->stateless()->user();
+        try {
+            $google = Socialite::driver('google')->stateless()->user();
+        } catch (Throwable $e) {
+            $this->logAuthFailure('callback', $e);
+
+            throw new HttpException(502, 'Google認証に失敗しました');
+        }
+
         $user = $this->saveGroupsUser($google);
 
         return [
@@ -32,9 +42,30 @@ class GoogleLoginController extends Controller
     public function apiLogin(Request $request)
     {
         $googleToken = $request->google_token;
-        $google = Socialite::driver('google')->userFromToken($googleToken);
+
+        try {
+            $google = Socialite::driver('google')->userFromToken($googleToken);
+        } catch (Throwable $e) {
+            $this->logAuthFailure('api_login', $e);
+
+            throw new HttpException(502, 'Google認証に失敗しました');
+        }
 
         return $this->saveGroupsUser($google);
+    }
+
+    /**
+     * access token・authorization code・client secret・callback query・
+     * 例外メッセージ自体（機密値を含み得る）をログへ出さず、切り分けに
+     * 必要な最小限の情報だけを記録する。
+     */
+    private function logAuthFailure(string $operation, Throwable $e): void
+    {
+        Log::warning('external_service.failure', [
+            'integration' => 'google_auth',
+            'operation' => $operation,
+            'exception' => get_class($e),
+        ]);
     }
 
     private function saveGroupsUser(GoogleUser $google)

--- a/src/app/Http/Controllers/Web/HealthController.php
+++ b/src/app/Http/Controllers/Web/HealthController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Web;
+
+use App\Http\Controllers\Controller;
+use App\Libs\HealthCheck;
+use Illuminate\Http\JsonResponse;
+
+class HealthController extends Controller
+{
+    public function index(HealthCheck $healthCheck): JsonResponse
+    {
+        $result = $healthCheck->run();
+
+        return response()->json(
+            $result,
+            $result['status'] === 'ok' ? 200 : 503
+        );
+    }
+}

--- a/src/app/Libs/ExternalHttpFailure.php
+++ b/src/app/Libs/ExternalHttpFailure.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Libs;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * HTTPレスポンスを伴わない外部HTTP失敗を、exec_resultsのNOT NULL制約に沿った
+ * 安全な固定値へ変換し、秘密情報（URL・ヘッダー・ボディ）を含めずにログへ
+ * 記録するための共通処理。
+ *
+ * DNS失敗・connect timeout・connection refused等の接続レベルの失敗は
+ * {@see ConnectException} として送出され、これは
+ * {@see RequestException} のサブクラスではない
+ * （どちらも {@see TransferException} の兄弟クラス）。
+ * そのため呼び出し側は RequestException だけでなく GuzzleException 全体を
+ * catch し、レスポンスの有無は hasResponse() で判定すること。
+ */
+class ExternalHttpFailure
+{
+    /**
+     * response_code は実際のHTTPステータスと衝突しない値（100〜599の範囲外）
+     * を使い、「レスポンスを伴わない失敗」であることを明示する。
+     */
+    public const NO_RESPONSE_CODE = 0;
+
+    public static function hasResponse(GuzzleException $e): bool
+    {
+        return $e instanceof RequestException && $e->getResponse() !== null;
+    }
+
+    /**
+     * @return array{response_code: int, response_header: string, response_body: string}
+     */
+    public static function noResponsePayload(GuzzleException $e): array
+    {
+        return [
+            'response_code' => self::NO_RESPONSE_CODE,
+            'response_header' => json_encode(['x_status' => 'no_response'], JSON_THROW_ON_ERROR),
+            'response_body' => json_encode([
+                'error' => 'no_response',
+                'exception' => get_class($e),
+            ], JSON_THROW_ON_ERROR),
+        ];
+    }
+
+    /**
+     * @param  array<string, scalar|null>  $context
+     */
+    public static function log(string $integration, GuzzleException $e, array $context = []): void
+    {
+        Log::warning('external_http.no_response', array_merge([
+            'integration' => $integration,
+            'exception' => get_class($e),
+        ], $context));
+    }
+}

--- a/src/app/Libs/HealthCheck.php
+++ b/src/app/Libs/HealthCheck.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Libs;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * "GET /health" が判定する内容をまとめる。公開レスポンスへは
+ * component名とok/ngだけを返し、詳細な理由はログでのみ確認できるようにする
+ * （実値・例外メッセージ・stack traceは含めない）。
+ */
+class HealthCheck
+{
+    /**
+     * 稼働に必須な設定。実値は返さず、存在確認だけを行う。
+     *
+     * @var array<string, string>
+     */
+    private const REQUIRED_CONFIG = [
+        'app_key' => 'app.key',
+        'db_host' => 'database.connections.mysql.host',
+        'db_database' => 'database.connections.mysql.database',
+        'db_username' => 'database.connections.mysql.username',
+        'db_password' => 'database.connections.mysql.password',
+        'google_client_id' => 'services.google.client_id',
+        'google_client_secret' => 'services.google.client_secret',
+        'google_callback_url' => 'services.google.redirect',
+        'google_calendar_api_key' => 'services.google_calendar.api_key',
+    ];
+
+    private const SCHEDULER_TASK = 'time:trigger';
+
+    public function __construct(private SchedulerHeartbeat $heartbeat) {}
+
+    /**
+     * @return array{status: string, components: array<string, string>}
+     */
+    public function run(): array
+    {
+        $components = [
+            'app' => 'ok',
+            'database' => $this->checkDatabase() ? 'ok' : 'ng',
+            'config' => $this->checkConfig() ? 'ok' : 'ng',
+            'scheduler' => $this->checkScheduler() ? 'ok' : 'ng',
+        ];
+
+        $status = in_array('ng', $components, true) ? 'ng' : 'ok';
+
+        return ['status' => $status, 'components' => $components];
+    }
+
+    private function checkDatabase(): bool
+    {
+        try {
+            DB::select('SELECT 1');
+
+            return true;
+        } catch (Throwable $e) {
+            Log::error('health_check.database_failure', [
+                'exception' => get_class($e),
+            ]);
+
+            return false;
+        }
+    }
+
+    private function checkConfig(): bool
+    {
+        $missing = [];
+        foreach (self::REQUIRED_CONFIG as $name => $configKey) {
+            $value = config($configKey);
+            if ($value === null || $value === '') {
+                $missing[] = $name;
+            }
+        }
+
+        if (! empty($missing)) {
+            // 欠落している設定「名」だけを記録し、実値は記録しない。
+            Log::error('health_check.config_missing', ['missing' => $missing]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function checkScheduler(): bool
+    {
+        $threshold = (int) config('health.scheduler.time_trigger_heartbeat_threshold');
+        $fresh = $this->heartbeat->isFresh(self::SCHEDULER_TASK, $threshold);
+
+        if (! $fresh) {
+            Log::error('health_check.scheduler_stale', [
+                'task' => self::SCHEDULER_TASK,
+                'threshold_seconds' => $threshold,
+            ]);
+        }
+
+        return $fresh;
+    }
+}

--- a/src/app/Libs/HolidayList.php
+++ b/src/app/Libs/HolidayList.php
@@ -2,6 +2,10 @@
 
 namespace App\Libs;
 
+use App\Exceptions\HolidayFetchException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Log;
 
 class HolidayList
@@ -31,28 +35,58 @@ class HolidayList
             }
         }
 
-        $holidays_url = sprintf(
-            'https://www.googleapis.com/calendar/v3/calendars/%s/events?'.
-            'key=%s&timeMin=%s&timeMax=%s&orderBy=startTime&singleEvents=true',
-            'ja.'.self::COUNTRY_CODES[$code].'.official%23holiday@group.v.calendar.google.com',
-            env('GOOGLE_CALENDAR_API_KEY'),
-            $year.'-01-01T00%3A00%3A00.000Z',
-            $year.'-12-31T00%3A00%3A00.000Z'
+        // カレンダーIDに含まれる "#" は事前に %23 へエンコードされた形式で
+        // Googleのドキュメントに記載されている。Guzzleは有効な%エンコード済み
+        // 文字列を再エンコードしないため、パス部分に直接埋め込む。
+        $calendar_path = sprintf(
+            'https://www.googleapis.com/calendar/v3/calendars/%s/events',
+            'ja.'.self::COUNTRY_CODES[$code].'.official%23holiday@group.v.calendar.google.com'
         );
 
-        if ($results = file_get_contents($holidays_url, true)) {
-            $result_data = json_decode($results);
-            $holidays = [];
-            foreach ($result_data->items as $item) {
-                $holidays[date('Y-m-d', strtotime($item->start->date))] = $item->summary;
-            }
-            ksort($holidays);
+        $client = app(Client::class);
+
+        try {
+            $response = $client->request('GET', $calendar_path, [
+                'query' => [
+                    'key' => config('services.google_calendar.api_key'),
+                    'timeMin' => $year.'-01-01T00:00:00.000Z',
+                    'timeMax' => $year.'-12-31T00:00:00.000Z',
+                    'orderBy' => 'startTime',
+                    'singleEvents' => 'true',
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            Log::warning('external_service.failure', [
+                'integration' => 'google_calendar',
+                'exception' => get_class($e),
+                'status' => $this->safeStatusCode($e),
+            ]);
+
+            // 元例外にはAPIキーを含むURLが含まれ得るため $previous としては保持しない。
+            throw new HolidayFetchException('Google Calendar APIからの祝日取得に失敗しました。');
         }
+
+        $result_data = json_decode((string) $response->getBody());
+        $holidays = [];
+        foreach ($result_data->items ?? [] as $item) {
+            $holidays[date('Y-m-d', strtotime($item->start->date))] = $item->summary;
+        }
+        ksort($holidays);
+
         $this->_holidays[$key] = $holidays;
         Log::info('holidays', ['create' => $key]);
         file_put_contents(base_path(self::HOLIDAYS_FILE), json_encode($this->_holidays, true));
 
         return $holidays;
+    }
+
+    private function safeStatusCode(GuzzleException $e): ?int
+    {
+        if ($e instanceof RequestException && $e->getResponse() !== null) {
+            return $e->getResponse()->getStatusCode();
+        }
+
+        return null;
     }
 
     private const HOLIDAYS_FILE = 'logs/holidays.json';

--- a/src/app/Libs/SchedulerHeartbeat.php
+++ b/src/app/Libs/SchedulerHeartbeat.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Libs;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * schedulerから起動されるArtisanコマンド（time:trigger・results:delete・
+ * holidays:update）の最終成功・失敗時刻を logs/ 配下のstatus fileへ記録する。
+ *
+ * DB schema変更やLaravel migrationを新設せず、本番deployで"logs/"が保持される
+ * 現在の構成を使って health check から scheduler停止を検知できるようにする
+ * ための最小限の仕組み（Issue #225）。時刻はUTCのISO8601形式で保存し、
+ * timezoneに依存した比較ミスを避ける。書き込みは一時ファイルへ書いてから
+ * rename する atomic writeとし、読み込み側が壊れた内容を見ないようにする。
+ */
+class SchedulerHeartbeat
+{
+    private const STATUS_FILE = 'logs/scheduler-heartbeat.json';
+
+    public function recordSuccess(string $task): void
+    {
+        $this->record($task, true);
+    }
+
+    public function recordFailure(string $task): void
+    {
+        $this->record($task, false);
+    }
+
+    /**
+     * @return array{status: string, last_success_at: ?string, last_failure_at: ?string}|null
+     */
+    public function status(string $task): ?array
+    {
+        return $this->readUnlocked()[$task] ?? null;
+    }
+
+    public function isFresh(string $task, int $thresholdSeconds): bool
+    {
+        $status = $this->status($task);
+        if ($status === null || empty($status['last_success_at'] ?? null)) {
+            return false;
+        }
+
+        $lastSuccess = CarbonImmutable::parse($status['last_success_at']);
+
+        // Carbon 3のdiffInSeconds()は既定で符号付きの差分を返すため、
+        // 前後関係に依存しないよう明示的に絶対値を指定する。
+        return CarbonImmutable::now()->diffInSeconds($lastSuccess, true) <= $thresholdSeconds;
+    }
+
+    public function path(): string
+    {
+        return $this->statusPath();
+    }
+
+    private function record(string $task, bool $success): void
+    {
+        $lockHandle = @fopen($this->lockPath(), 'c');
+        if ($lockHandle === false) {
+            return;
+        }
+
+        try {
+            flock($lockHandle, LOCK_EX);
+            $data = $this->readUnlocked();
+            $now = CarbonImmutable::now('UTC')->toIso8601String();
+            $entry = $data[$task] ?? [];
+            $entry['status'] = $success ? 'success' : 'failure';
+            if ($success) {
+                $entry['last_success_at'] = $now;
+            } else {
+                $entry['last_failure_at'] = $now;
+            }
+            $data[$task] = $entry;
+            $this->writeAtomic($data);
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function readUnlocked(): array
+    {
+        $path = $this->statusPath();
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $contents = @file_get_contents($path);
+        if ($contents === false || $contents === '') {
+            return [];
+        }
+
+        $decoded = json_decode($contents, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string, array<string, string>>  $data
+     */
+    private function writeAtomic(array $data): void
+    {
+        $path = $this->statusPath();
+        $tmpPath = $path.'.'.getmypid().'.tmp';
+        file_put_contents($tmpPath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        rename($tmpPath, $path);
+    }
+
+    private function statusPath(): string
+    {
+        return base_path(self::STATUS_FILE);
+    }
+
+    private function lockPath(): string
+    {
+        return $this->statusPath().'.lock';
+    }
+}

--- a/src/config/health.php
+++ b/src/config/health.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Scheduler heartbeat
+    |--------------------------------------------------------------------------
+    |
+    | "time:trigger" は毎分実行される想定だが、本番でLaravel Schedulerを
+    | 起動するOS側cronの実際の間隔はリポジトリから確認できない
+    | (docs/current-operations.md 5.5節)。そのため、想定間隔(1分)より
+    | 十分に余裕を持たせた既定値とし、環境ごとに調整できるようにする。
+    |
+    */
+
+    'scheduler' => [
+        'time_trigger_heartbeat_threshold' => (int) env('HEALTH_SCHEDULER_HEARTBEAT_THRESHOLD', 300),
+    ],
+
+];

--- a/src/config/services.php
+++ b/src/config/services.php
@@ -23,4 +23,8 @@ return [
         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
         'redirect' => env('GOOGLE_CALLBACK_URL'),
     ],
+
+    'google_calendar' => [
+        'api_key' => env('GOOGLE_CALENDAR_API_KEY'),
+    ],
 ];

--- a/src/phpstan-baseline.neon
+++ b/src/phpstan-baseline.neon
@@ -19,16 +19,3 @@ parameters:
 			message: "#^Caught class App\\\\Http\\\\Controllers\\\\Api\\\\Exception not found\\.$#"
 			count: 2
 			path: app/Http/Controllers/Api/CalendarController.php
-
-		-
-			message: "#^Variable \\$holidays might not be defined\\.$#"
-			count: 2
-			path: app/Libs/HolidayList.php
-
-		-
-			# Larastan 3で新設されたルール(larastan.noEnvCallsOutsideOfConfig)による
-			# 新規検出。既存のconfig/構成を変更しないためbaseline化する。
-			message: "#^Called 'env' outside of the config directory which returns null when the config is cached, use 'config'\\.$#"
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
-			path: app/Libs/HolidayList.php

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -10,6 +10,8 @@ Route::get('/', function () {
     ];
 });
 
+Route::get('/health', 'HealthController@index');
+
 Route::get('/holiday/cache/clear', function () {
     return [
         'holidays' => app()->make('HolidayList')->clear(),

--- a/src/tests/Feature/Api/CommandExecControllerTest.php
+++ b/src/tests/Feature/Api/CommandExecControllerTest.php
@@ -6,12 +6,14 @@ use App\Models\Command;
 use App\Models\SummarizeCommand;
 use App\Models\User;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 class CommandExecControllerTest extends TestCase
@@ -177,21 +179,71 @@ class CommandExecControllerTest extends TestCase
         $this->assertSame(500, $body['response_code']);
     }
 
-    public function test_レスポンスを伴わない_request_exceptionは現状_type_errorになる()
+    public function test_レスポンスを伴わない接続失敗は_type_errorにならず安全な固定表現で結果が返る()
     {
-        // 保存処理は必ずレスポンスオブジェクトを受け取る前提だが、
-        // RequestException::getResponse() は null を返し得るため現状は例外になる
-        // (docs/current-architecture.md 10.4)。修正はこのIssueの対象外であり、
-        // 現行仕様を保護する回帰テストとして記録する。
+        // Issue #225: RequestException::getResponse() が null になり得る
+        // (DNS失敗・connect timeout・connection refused等)接続失敗を、
+        // TypeErrorで落とさずに安全な固定表現へ変換する新挙動のテスト。
+        // #212で追加されたTypeErrorを記録する回帰テストはこの挙動へ更新した。
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                $context_json = json_encode($context);
+
+                return $message === 'external_http.no_response'
+                    && $context['integration'] === 'command_exec'
+                    && ! str_contains($context_json, 'secret.example.test')
+                    && ! str_contains($context_json, 'token=leak');
+            });
         $this->bindMockClient([
-            new RequestException('connection failed', new Psr7Request('GET', 'http://example.test')),
+            new ConnectException(
+                'cURL error 6: Could not resolve host: secret.example.test?token=leak',
+                new Psr7Request('GET', 'http://secret.example.test?token=leak')
+            ),
         ]);
         $user = User::factory()->create();
         $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
 
-        $this->withoutExceptionHandling();
-        $this->expectException(\TypeError::class);
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/'.$command->id);
 
-        $this->actingAs($user, 'api')->postJson('/api/exec/command/'.$command->id);
+        $response->assertStatus(200);
+        $body = $response->json()[0];
+        $this->assertSame(0, $body['response_code']);
+        $decodedBody = json_decode($body['response_body'], true);
+        $this->assertSame('no_response', $decodedBody['error']);
+        $this->assertSame(ConnectException::class, $decodedBody['exception']);
+    }
+
+    public function test_response_を伴わない_request_exceptionも_type_errorにならず安全な固定表現で結果が返る()
+    {
+        // ConnectExceptionではない、レスポンスを持たないRequestException
+        // （接続確立後の転送エラー等）も同様に扱われることを確認する。
+        $this->bindMockClient([
+            new RequestException('Error completing request', new Psr7Request('GET', 'http://example.test')),
+        ]);
+        $user = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/'.$command->id);
+
+        $response->assertStatus(200);
+        $body = $response->json()[0];
+        $this->assertSame(0, $body['response_code']);
+    }
+
+    public function test_response_ありの_request_exceptionは_no_responseとして扱われない()
+    {
+        $this->bindMockClient([new Response(503, [], 'unavailable')]);
+        $user = User::factory()->create();
+        $command = Command::factory()->create(['target_id' => $user->id, 'target_type' => 'user']);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/exec/command/'.$command->id);
+
+        $response->assertStatus(200);
+        $body = $response->json()[0];
+        $this->assertSame(503, $body['response_code']);
     }
 }

--- a/src/tests/Feature/Console/TimeTriggerCommandTest.php
+++ b/src/tests/Feature/Console/TimeTriggerCommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Console;
 
+use App\Exceptions\HolidayFetchException;
+use App\Libs\SchedulerHeartbeat;
 use App\Models\Calender;
 use App\Models\Command;
 use App\Models\ExecResult;
@@ -9,12 +11,16 @@ use App\Models\OnetimeSkip;
 use App\Models\TimeTrigger;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Mockery;
 use Tests\Doubles\FakeHolidayList;
 use Tests\TestCase;
 
@@ -31,6 +37,15 @@ class TimeTriggerCommandTest extends TestCase
     use DatabaseTransactions;
 
     private const FIXED_JST_DATETIME = '2026-06-15 10:00:00';
+
+    protected function tearDown(): void
+    {
+        $path = app(SchedulerHeartbeat::class)->path();
+        @unlink($path);
+        @unlink($path.'.lock');
+
+        parent::tearDown();
+    }
 
     private function freezeDatabaseNow(string $jstDateTime = self::FIXED_JST_DATETIME): void
     {
@@ -314,5 +329,103 @@ class TimeTriggerCommandTest extends TestCase
         Artisan::call('time:trigger');
 
         $this->assertSame(1, ExecResult::where('trigger_id', $trigger->id)->count());
+    }
+
+    public function test_外部_htt_pがエラー応答を返した場合はそのステータスがexec_resultsへ反映される()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(500, [], 'server-error')]);
+        $trigger = $this->createTrigger();
+
+        Artisan::call('time:trigger');
+
+        $result = ExecResult::where('trigger_id', $trigger->id)->first();
+        $this->assertNotNull($result);
+        $this->assertSame(500, $result->response_code);
+    }
+
+    public function test_レスポンスを伴わない接続失敗はexec_resultsへ安全な固定表現で保存される()
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                $context_json = json_encode($context);
+
+                return $message === 'external_http.no_response'
+                    && $context['integration'] === 'time_trigger'
+                    && ! str_contains($context_json, 'secret.example.test')
+                    && ! str_contains($context_json, 'token=leak');
+            });
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([
+            new ConnectException(
+                'cURL error 6: Could not resolve host: secret.example.test?token=leak',
+                new Psr7Request('GET', 'http://secret.example.test?token=leak')
+            ),
+        ]);
+        $trigger = $this->createTrigger();
+
+        Artisan::call('time:trigger');
+
+        $result = ExecResult::where('trigger_id', $trigger->id)->first();
+        $this->assertNotNull($result);
+        $this->assertSame(0, $result->response_code);
+        $decodedBody = json_decode($result->response_body, true);
+        $this->assertSame('no_response', $decodedBody['error']);
+        $this->assertSame(ConnectException::class, $decodedBody['exception']);
+
+        // 個々の外部HTTP失敗はscheduler自体の成功判定には影響しない。
+        $heartbeat = app(SchedulerHeartbeat::class);
+        $this->assertSame('success', $heartbeat->status('time:trigger')['status']);
+    }
+
+    public function test_scheduler成功時にheartbeatが更新される()
+    {
+        $this->freezeDatabaseNow();
+        $this->fakeHolidaysForToday(false);
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $this->createTrigger();
+
+        Artisan::call('time:trigger');
+
+        $heartbeat = app(SchedulerHeartbeat::class);
+        $status = $heartbeat->status('time:trigger');
+        $this->assertSame('success', $status['status']);
+        $this->assertNotEmpty($status['last_success_at']);
+        $this->assertTrue($heartbeat->isFresh('time:trigger', 60));
+    }
+
+    public function test_google_calendar失敗時は該当トリガーだけ安全にスキップされ_schedulerは失敗扱いにならない()
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('time_trigger.holiday_lookup_failed', Mockery::on(function (array $context) {
+                return $context['exception'] === HolidayFetchException::class;
+            }));
+        $this->freezeDatabaseNow();
+        $this->bindMockClient([new Response(200, [], 'ok')]);
+        $failingHolidayList = new class
+        {
+            public function getHolidays($code, $year)
+            {
+                throw new HolidayFetchException('Google Calendar APIからの祝日取得に失敗しました。');
+            }
+
+            public function clear()
+            {
+                return [];
+            }
+        };
+        $this->app->instance('HolidayList', $failingHolidayList);
+        $trigger = $this->createTrigger(['holiday_decision' => 'not_check']);
+
+        Artisan::call('time:trigger');
+
+        $this->assertSame(0, ExecResult::where('trigger_id', $trigger->id)->count());
+
+        $heartbeat = app(SchedulerHeartbeat::class);
+        $this->assertSame('success', $heartbeat->status('time:trigger')['status']);
     }
 }

--- a/src/tests/Feature/Console/UpdateHolidayCacheCommandTest.php
+++ b/src/tests/Feature/Console/UpdateHolidayCacheCommandTest.php
@@ -2,14 +2,26 @@
 
 namespace Tests\Feature\Console;
 
+use App\Libs\SchedulerHeartbeat;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Artisan;
+use RuntimeException;
 use Tests\Doubles\FakeHolidayList;
 use Tests\TestCase;
+use Throwable;
 
 class UpdateHolidayCacheCommandTest extends TestCase
 {
     use DatabaseTransactions;
+
+    protected function tearDown(): void
+    {
+        $path = app(SchedulerHeartbeat::class)->path();
+        @unlink($path);
+        @unlink($path.'.lock');
+
+        parent::tearDown();
+    }
 
     public function test_キャッシュをクリアしたうえで当年と翌年の日本の祝日を取得する()
     {
@@ -20,5 +32,46 @@ class UpdateHolidayCacheCommandTest extends TestCase
 
         $this->assertSame(1, $fake->clearedCalls);
         $this->assertSame(['jp'.date('Y'), 'jp'.(date('Y') + 1)], $fake->requestedKeys);
+    }
+
+    public function test_成功時はheartbeatに成功時刻が記録される()
+    {
+        $this->app->instance('HolidayList', new FakeHolidayList);
+
+        Artisan::call('holidays:update');
+
+        $heartbeat = app(SchedulerHeartbeat::class);
+        $status = $heartbeat->status('holidays:update');
+        $this->assertSame('success', $status['status']);
+        $this->assertNotEmpty($status['last_success_at']);
+    }
+
+    public function test_失敗時はheartbeatが失敗として記録され成功時刻は記録されない()
+    {
+        $failing = new class
+        {
+            public function clear()
+            {
+                throw new RuntimeException('clear failed');
+            }
+
+            public function getHolidays($code, $year)
+            {
+                return [];
+            }
+        };
+        $this->app->instance('HolidayList', $failing);
+
+        try {
+            Artisan::call('holidays:update');
+            $this->fail('例外が発生することを期待しています');
+        } catch (Throwable $e) {
+            // 想定どおりの失敗
+        }
+
+        $heartbeat = app(SchedulerHeartbeat::class);
+        $status = $heartbeat->status('holidays:update');
+        $this->assertSame('failure', $status['status']);
+        $this->assertArrayNotHasKey('last_success_at', $status);
     }
 }

--- a/src/tests/Feature/Web/GoogleLoginControllerTest.php
+++ b/src/tests/Feature/Web/GoogleLoginControllerTest.php
@@ -2,12 +2,17 @@
 
 namespace Tests\Feature\Web;
 
+use App\Http\Controllers\Web\GoogleLoginController;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\InvalidStateException;
 use Laravel\Socialite\Two\User as GoogleUser;
 use Mockery;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Tests\TestCase;
 
 class GoogleLoginControllerTest extends TestCase
@@ -71,6 +76,62 @@ class GoogleLoginControllerTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertSame(1, User::where('groups_id', $group->id)->where('owner_flag', true)->count());
+    }
+
+    public function test_callbackでgoogle認証が失敗すると502を返し機密値をログへ出さない()
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                $context_json = json_encode($context);
+
+                return $message === 'external_service.failure'
+                    && $context['integration'] === 'google_auth'
+                    && $context['operation'] === 'callback'
+                    && $context['exception'] === InvalidStateException::class
+                    && ! str_contains($context_json, 'leaked-authorization-code')
+                    && ! str_contains($context_json, 'leaked-state');
+            });
+        $provider = Mockery::mock();
+        $provider->shouldReceive('stateless')->once()->andReturnSelf();
+        $provider->shouldReceive('user')->once()->andThrow(
+            new InvalidStateException('Invalid state: code=leaked-authorization-code')
+        );
+        Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+        $response = $this->get('/login/callback?code=leaked-authorization-code&state=leaked-state');
+
+        $response->assertStatus(502);
+    }
+
+    public function test_api_loginでgoogle認証が失敗すると502を返し機密値をログへ出さない()
+    {
+        // apiLogin()にはルートが割り当てられていない(既存の未使用コード)ため、
+        // コントローラーを直接呼び出して検証する。
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                $context_json = json_encode($context);
+
+                return $message === 'external_service.failure'
+                    && $context['integration'] === 'google_auth'
+                    && $context['operation'] === 'api_login'
+                    && ! str_contains($context_json, 'secret-google-token');
+            });
+        $provider = Mockery::mock();
+        $provider->shouldReceive('userFromToken')->once()->with('secret-google-token')->andThrow(
+            new InvalidStateException('invalid token: secret-google-token')
+        );
+        Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+        $request = Request::create('/', 'POST', ['google_token' => 'secret-google-token']);
+
+        try {
+            app(GoogleLoginController::class)->apiLogin($request);
+            $this->fail('例外が発生することを期待しています');
+        } catch (HttpException $e) {
+            $this->assertSame(502, $e->getStatusCode());
+        }
     }
 
     public function test_既存の所有者ユーザーがいる場合は再利用され重複作成されない()

--- a/src/tests/Feature/Web/HealthControllerTest.php
+++ b/src/tests/Feature/Web/HealthControllerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Libs\SchedulerHeartbeat;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Tests\TestCase;
+
+class HealthControllerTest extends TestCase
+{
+    private function heartbeat(): SchedulerHeartbeat
+    {
+        return app(SchedulerHeartbeat::class);
+    }
+
+    private function setValidConfig(): void
+    {
+        config([
+            'app.key' => 'base64:'.base64_encode(str_repeat('a', 32)),
+            'database.connections.mysql.host' => 'db',
+            'database.connections.mysql.database' => 'hw',
+            'database.connections.mysql.username' => 'user',
+            'database.connections.mysql.password' => 'password',
+            'services.google.client_id' => 'test-google-client-id',
+            'services.google.client_secret' => 'test-google-client-secret',
+            'services.google.redirect' => 'http://localhost:8000/login/callback',
+            'services.google_calendar.api_key' => 'test-google-calendar-api-key',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $path = $this->heartbeat()->path();
+        @unlink($path);
+        @unlink($path.'.lock');
+
+        parent::tearDown();
+    }
+
+    public function test_すべての条件を満たすとhttp200を返す()
+    {
+        $this->setValidConfig();
+        $this->heartbeat()->recordSuccess('time:trigger');
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'status' => 'ok',
+            'components' => [
+                'app' => 'ok',
+                'database' => 'ok',
+                'config' => 'ok',
+                'scheduler' => 'ok',
+            ],
+        ]);
+    }
+
+    public function test_db接続に失敗するとhttp503を返す()
+    {
+        $this->setValidConfig();
+        $this->heartbeat()->recordSuccess('time:trigger');
+        DB::shouldReceive('select')->once()->andThrow(new RuntimeException('connection refused'));
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(503);
+        $this->assertSame('ng', $response->json('components.database'));
+        $this->assertSame('ng', $response->json('status'));
+    }
+
+    public function test_必須設定が不足しているとhttp503を返す()
+    {
+        $this->setValidConfig();
+        config(['services.google_calendar.api_key' => '']);
+        $this->heartbeat()->recordSuccess('time:trigger');
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(503);
+        $this->assertSame('ng', $response->json('components.config'));
+    }
+
+    public function test_heartbeatが新しい場合はschedulerが正常判定になる()
+    {
+        $this->setValidConfig();
+        $this->heartbeat()->recordSuccess('time:trigger');
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(200);
+        $this->assertSame('ok', $response->json('components.scheduler'));
+    }
+
+    public function test_heartbeatが古い場合はschedulerが異常判定になりhttp503を返す()
+    {
+        $this->setValidConfig();
+        file_put_contents($this->heartbeat()->path(), json_encode([
+            'time:trigger' => [
+                'status' => 'success',
+                'last_success_at' => now('UTC')->subHours(1)->toIso8601String(),
+            ],
+        ]));
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(503);
+        $this->assertSame('ng', $response->json('components.scheduler'));
+    }
+
+    public function test_heartbeatが存在しない場合はschedulerが異常判定になりhttp503を返す()
+    {
+        $this->setValidConfig();
+        @unlink($this->heartbeat()->path());
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(503);
+        $this->assertSame('ng', $response->json('components.scheduler'));
+    }
+
+    public function test_scheduler失敗の記録は成功時刻として扱われずhttp503を返す()
+    {
+        $this->setValidConfig();
+        $this->heartbeat()->recordFailure('time:trigger');
+
+        $response = $this->getJson('/health');
+
+        $response->assertStatus(503);
+        $this->assertSame('ng', $response->json('components.scheduler'));
+    }
+
+    public function test_レスポンスに秘密情報や内部パスが含まれない()
+    {
+        $this->setValidConfig();
+        config(['database.connections.mysql.password' => 'super-secret-password']);
+        $this->heartbeat()->recordSuccess('time:trigger');
+
+        $response = $this->getJson('/health');
+        $response->assertJsonStructure(['status', 'components' => ['app', 'database', 'config', 'scheduler']]);
+
+        $body = $response->getContent();
+        $this->assertStringNotContainsString('super-secret-password', $body);
+        $this->assertStringNotContainsString('test-google-calendar-api-key', $body);
+        $this->assertStringNotContainsString('test-google-client-secret', $body);
+        $this->assertStringNotContainsString(base_path(), $body);
+        $this->assertStringNotContainsString(gethostname(), $body);
+    }
+}

--- a/src/tests/Unit/Libs/HolidayListTest.php
+++ b/src/tests/Unit/Libs/HolidayListTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Unit\Libs;
+
+use App\Exceptions\HolidayFetchException;
+use App\Libs\HolidayList;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class HolidayListTest extends TestCase
+{
+    private function bindMockClient(array $responses): void
+    {
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $this->app->instance(Client::class, new Client(['handler' => $handlerStack]));
+    }
+
+    private function cacheFile(): string
+    {
+        return base_path('logs/holidays.json');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        @unlink($this->cacheFile());
+        config(['services.google_calendar.api_key' => 'test-calendar-api-key']);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->cacheFile());
+        parent::tearDown();
+    }
+
+    public function test_取得に成功すると祝日一覧を返しキャッシュへ保存する()
+    {
+        $body = json_encode([
+            'items' => [
+                ['start' => ['date' => '2026-01-01'], 'summary' => '元日'],
+            ],
+        ]);
+        $this->bindMockClient([new Response(200, [], $body)]);
+
+        $holidays = (new HolidayList)->getHolidays('jp', 2026);
+
+        $this->assertSame(['2026-01-01' => '元日'], $holidays);
+        $this->assertFileExists($this->cacheFile());
+    }
+
+    public function test_接続失敗時はholiday_fetch_exceptionを投げapiキーやurlをログへ出さない()
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                $context_json = json_encode($context);
+
+                return $message === 'external_service.failure'
+                    && $context['integration'] === 'google_calendar'
+                    && ! str_contains($context_json, 'test-calendar-api-key')
+                    && ! str_contains($context_json, 'googleapis.com');
+            });
+        $this->bindMockClient([
+            new ConnectException(
+                'cURL error 6: Could not resolve host: www.googleapis.com (key=test-calendar-api-key)',
+                new Psr7Request(
+                    'GET',
+                    'https://www.googleapis.com/calendar/v3/calendars/x/events?key=test-calendar-api-key'
+                )
+            ),
+        ]);
+
+        $holidayList = new HolidayList;
+
+        try {
+            $holidayList->getHolidays('jp', 2026);
+            $this->fail('例外が発生することを期待しています');
+        } catch (HolidayFetchException $e) {
+            $this->assertStringNotContainsString('test-calendar-api-key', $e->getMessage());
+            $this->assertNull($e->getPrevious());
+        }
+
+        $this->assertFileDoesNotExist($this->cacheFile());
+    }
+
+    public function test_4xxレスポンスでも例外メッセージとログにapiキーを含めない()
+    {
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) {
+                return $message === 'external_service.failure' && $context['status'] === 403;
+            });
+        $this->bindMockClient([new Response(403, [], 'Forbidden')]);
+
+        $holidayList = new HolidayList;
+
+        try {
+            $holidayList->getHolidays('jp', 2026);
+            $this->fail('例外が発生することを期待しています');
+        } catch (HolidayFetchException $e) {
+            $this->assertStringNotContainsString('test-calendar-api-key', $e->getMessage());
+        }
+    }
+}

--- a/src/tests/Unit/Libs/SchedulerHeartbeatTest.php
+++ b/src/tests/Unit/Libs/SchedulerHeartbeatTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Unit\Libs;
+
+use App\Libs\SchedulerHeartbeat;
+use Tests\TestCase;
+
+class SchedulerHeartbeatTest extends TestCase
+{
+    private function heartbeat(): SchedulerHeartbeat
+    {
+        return new SchedulerHeartbeat;
+    }
+
+    protected function tearDown(): void
+    {
+        $path = $this->heartbeat()->path();
+        @unlink($path);
+        @unlink($path.'.lock');
+
+        parent::tearDown();
+    }
+
+    public function test_成功を記録するとlast_success_atが更新される()
+    {
+        $heartbeat = $this->heartbeat();
+
+        $heartbeat->recordSuccess('time:trigger');
+
+        $status = $heartbeat->status('time:trigger');
+        $this->assertSame('success', $status['status']);
+        $this->assertNotEmpty($status['last_success_at']);
+    }
+
+    public function test_失敗を記録してもlast_success_atは記録されない()
+    {
+        $heartbeat = $this->heartbeat();
+
+        $heartbeat->recordFailure('time:trigger');
+
+        $status = $heartbeat->status('time:trigger');
+        $this->assertSame('failure', $status['status']);
+        $this->assertArrayNotHasKey('last_success_at', $status);
+        $this->assertFalse($heartbeat->isFresh('time:trigger', 300));
+    }
+
+    public function test_成功後に失敗してもlast_success_atは保持されたままstatusがfailureになる()
+    {
+        $heartbeat = $this->heartbeat();
+        $heartbeat->recordSuccess('time:trigger');
+        $successAt = $heartbeat->status('time:trigger')['last_success_at'];
+
+        $heartbeat->recordFailure('time:trigger');
+
+        $status = $heartbeat->status('time:trigger');
+        $this->assertSame('failure', $status['status']);
+        $this->assertSame($successAt, $status['last_success_at']);
+        $this->assertArrayHasKey('last_failure_at', $status);
+    }
+
+    public function test_閾値内ならis_freshはtrueになる()
+    {
+        $heartbeat = $this->heartbeat();
+        $heartbeat->recordSuccess('time:trigger');
+
+        $this->assertTrue($heartbeat->isFresh('time:trigger', 60));
+    }
+
+    public function test_記録が存在しない場合is_freshはfalseになる()
+    {
+        $heartbeat = $this->heartbeat();
+
+        $this->assertFalse($heartbeat->isFresh('time:trigger', 300));
+    }
+
+    public function test_閾値を超えるとis_freshはfalseになる()
+    {
+        $heartbeat = $this->heartbeat();
+        file_put_contents($heartbeat->path(), json_encode([
+            'time:trigger' => [
+                'status' => 'success',
+                'last_success_at' => now('UTC')->subSeconds(120)->toIso8601String(),
+            ],
+        ]));
+
+        $this->assertFalse($heartbeat->isFresh('time:trigger', 60));
+    }
+
+    public function test_タイムゾーンが異なる時刻表現でも正しく比較される()
+    {
+        $heartbeat = $this->heartbeat();
+        // +09:00オフセット付きの時刻をUTC比較しても新しいと判定される
+        file_put_contents($heartbeat->path(), json_encode([
+            'time:trigger' => [
+                'status' => 'success',
+                'last_success_at' => now('Asia/Tokyo')->toIso8601String(),
+            ],
+        ]));
+
+        $this->assertTrue($heartbeat->isFresh('time:trigger', 60));
+    }
+
+    public function test_破損したstatusファイルは記録なしとして扱われる()
+    {
+        $heartbeat = $this->heartbeat();
+        file_put_contents($heartbeat->path(), '{invalid-json');
+
+        $this->assertNull($heartbeat->status('time:trigger'));
+        $this->assertFalse($heartbeat->isFresh('time:trigger', 300));
+    }
+
+    public function test_異なるタスク名は別々に記録される()
+    {
+        $heartbeat = $this->heartbeat();
+        $heartbeat->recordSuccess('time:trigger');
+        $heartbeat->recordFailure('results:delete');
+
+        $this->assertSame('success', $heartbeat->status('time:trigger')['status']);
+        $this->assertSame('failure', $heartbeat->status('results:delete')['status']);
+        $this->assertNull($heartbeat->status('holidays:update'));
+    }
+}


### PR DESCRIPTION
## 概要

Issue #225 に基づき、以下を追加・修正した。

### 1. health check (`GET /health`)
- DB接続（`SELECT 1`）・稼働に必須な設定（`APP_KEY`・DB接続情報・Google認証/Calendar設定）の存在・scheduler heartbeat（`time:trigger`の最終成功が閾値内）を判定し、すべてokならHTTP 200、いずれかngならHTTP 503を返す。
- 公開レスポンスは `{"status": "ok|ng", "components": {...}}` の形式のみとし、DB接続情報・ホスト名・filesystem path・APP_KEY・Google認証情報・例外メッセージ・stack traceは一切含めない。詳細はログでのみ確認できる。
- 既存の `/`（server/DB時刻を返す簡易エンドポイント）は変更していない。

### 2. scheduler heartbeat
- DB schema変更・Laravel migration新設なしで、`logs/scheduler-heartbeat.json`（本番deployで保持される`logs/`配下）へ、`time:trigger`・`results:delete`・`holidays:update`それぞれの最終成功/失敗時刻をUTC ISO8601形式で記録する`App\Libs\SchedulerHeartbeat`を追加。
- 各コマンドの`handle()`を`try/catch`し、成功/失敗をheartbeatへ記録（失敗時は再throwしてexit codeは維持）。書き込みは一時ファイル→`rename()`のatomic writeとし、`flock`で排他制御。
- `/health`は`time:trigger`のheartbeatだけを判定対象にし、`results:delete`（毎時）・`holidays:update`（月次）は記録のみでhealth判定には使わない（月次ジョブの非実行日を異常扱いしないため）。

### 3. 外部HTTPの「レスポンスなし」失敗
- `CommandExecController`・`TimeTrigger`で、DNS失敗・connect timeout・connection refused等の接続失敗（`ConnectException`。`RequestException`のサブクラスではないため`GuzzleException`全体をcatchするよう修正）でTypeErrorが発生していた挙動を修正。
- レスポンスなし失敗は`response_code=0`・`response_header`/`response_body`に`{"error":"no_response","exception":...}`という固定表現で保存/返却する（`exec_results`のNOT NULL制約はそのまま）。既存の`exec_results`スキーマは変更していない。
- #212で追加された「レスポンスを伴わないRequestExceptionはTypeErrorになる」回帰テストは、この新挙動を検証するテストへ更新した。

### 4. Google認証 / Google Calendar失敗の記録
- `HolidayList`をGuzzle経由（`app(Client::class)`）に変更し、テストからMockHandlerで外部通信をmockできるようにした（新規HTTP client依存は追加していない）。
- Google Calendar API keyを含むURLでの失敗時、元のGuzzle例外メッセージ（URLを含み得る）をログ・例外へ含めず、`integration`・`exception`クラス名・（取得できる場合のみ）HTTPステータスだけを記録する。
- `GoogleLoginController`（callback/api_login）でも同様に、access token・authorization code・client secret・callback query・生の例外メッセージをログへ出さず、`integration=google_auth`・`operation`・`exception`クラス名のみを記録し、502を返す。

### 5. 秘密情報漏洩防止
- 上記のとおり、ログ・health応答のいずれにも実値やURL・トークンを含めない設計とし、テストで確認している。

### 6. Slack通知
- **採用しなかった**。本番でruntime用`LOG_SLACK_WEBHOOK_URL`が設定済みか確認できないこと、GitHub Actions用`SLACK_WEBHOOK_URL`は流用しないこと、必須化を避ける方針を踏まえ、今回はログと`/health`のみで最低要件を満たす設計とした（`docs/monitoring.md` 10節に理由を記載）。

### 7. ドキュメント
- `docs/monitoring.md`を追加し、READMEのドキュメント一覧からリンク。`deployment-checklist.md`の主要機能確認/scheduler確認にも`/health`・heartbeatへの最小限のリンクを追加した。

## 追加・更新したテスト

- `SchedulerHeartbeatTest`（Unit）: 成功/失敗記録、freshness判定、タイムゾーン非依存の比較、破損ファイル耐性。
- `HealthControllerTest`（Feature）: 正常200、DB失敗503、必須設定不足503、heartbeat新旧・不在での判定、レスポンスに秘密情報が含まれないこと。
- `HolidayListTest`（Unit）: 取得成功、接続失敗時の安全なログ・例外、4xx失敗時のログ。
- `CommandExecControllerTest`・`TimeTriggerCommandTest`: レスポンスあり4xx/5xx、レスポンスなし接続失敗（安全な固定表現・ログ）、Google Calendar失敗時の該当トリガーのみスキップ、scheduler成功/失敗記録。
- `GoogleLoginControllerTest`: callback/api_login失敗時の502応答とログの機密値非包含。
- `UpdateHolidayCacheCommandTest`: heartbeat成功/失敗記録。

## make check

Pint・PHPStan（Larastan）・`php artisan test`（97件）すべて成功。

## 本番操作について

本番XServerへの接続、cron設定変更、PHP切り替え、tag作成・deployは行っていない。

Closes #225