### PR TITLE
CodexによるPull Requestレビュー運用を導入する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Codex等のAIエージェントがこのリポジトリで作業する際に守�
 - 継続運用向けの整理版アーキテクチャ: [`docs/architecture.md`](docs/architecture.md)
 - ドメインルール: [`docs/domain.md`](docs/domain.md)
 - ローカル・CI・本番の運用詳細: [`docs/current-operations.md`](docs/current-operations.md)
+- Pull Requestレビュー運用: [`docs/pull-request-review.md`](docs/pull-request-review.md)
 - 秘密情報の扱い: [`docs/secrets-management.md`](docs/secrets-management.md)
 - 依存関係更新（Dependabot）の運用: [`docs/dependency-updates.md`](docs/dependency-updates.md)
 - セットアップ・日常コマンド: [`README.md`](README.md)
@@ -87,6 +88,35 @@ make check
 - `make check` が成功していること（失敗した場合は原因を修正するか、修正できない場合はPR本文に明記する）。
 - 変更内容・検証結果（`make check` の結果）を日本語でPR本文に簡潔に記載すること。
 - スコープ外の変更（無関係なリファクタリング、ドキュメント整備タスクでのアプリケーションコード変更など）を含めないこと。
+- Codex Code Reviewの運用は [`docs/pull-request-review.md`](docs/pull-request-review.md) に従うこと。
+
+## Code Review Rules
+
+Codex Code Reviewでは、フォーマットや一般論よりも、対象Issueの意図に対する正しさと本リポジトリ固有の安全性を優先して確認する。
+
+### Issue・仕様との整合
+
+- PRが対象Issueの目的・完了条件を満たしているか確認する。
+- Issueにない無関係なリファクタリング、依存追加、schema変更、本番運用変更を混入させていないか確認する。
+- 既存の設計・運用ドキュメントが正として指定されている場合、一般的な実装へ勝手に置き換えていないか確認する。
+
+### セキュリティ・外部連携
+
+- 認証・認可の抜け、ユーザー/グループ境界の崩れ、秘密情報や個人情報のレスポンス・ログへの漏洩を優先して指摘する。
+- Google認証、Google Calendar、任意の外部HTTP実行では、失敗時の挙動と秘密情報の扱いに回帰がないか確認する。
+- 外部HTTPのテストが実サービスへ通信していないか確認する。
+
+### Scheduler・DB・本番運用
+
+- `time:trigger`等のScheduler処理について、実行条件・失敗処理・heartbeat・既存の定期実行挙動を壊していないか確認する。
+- DB schema変更や既存データへ影響する処理が、対象Issueで明示されないまま追加されていないか確認する。
+- deploy workflow、tag、Cron、本番PHP、backup/rollbackに関わる変更では、既存runbookや安全条件を弱めていないか確認する。
+
+### レビューの優先度
+
+- 重大な正しさ・セキュリティ・データ損失・本番障害につながる問題を優先する。
+- Laravel PintやPHPStan/Larastan、既存テストで機械的に検出できる軽微なスタイル指摘を重複して列挙しない。
+- 好みだけの命名変更や、対象Issueと無関係なアーキテクチャ変更を要求しない。
 
 ## 安全上の必須ルール
 

--- a/docs/pull-request-review.md
+++ b/docs/pull-request-review.md
@@ -1,0 +1,69 @@
+# Pull Requestレビュー運用
+
+この文書は、`holidays-webhook-server` のPull RequestでCodex Code Reviewと既存のGitHub CIをどう使うかを定義する。
+
+## 1. Codex Code Review
+
+このリポジトリでは、GitHubに接続したCodex Code Reviewを追加のレビュー手段として利用する。
+
+Codexの公式仕様では、対象リポジトリをCodex cloudへ接続し、Codex settingsでリポジトリの **Code review** を有効にする。すべての新規Pull Requestを自動レビューする場合は、同じ設定画面で **Automatic reviews** を有効にする。
+
+自動レビューを有効にした場合、Pull Requestが新たにreview対象としてopenされたときにCodexレビューが起動する。
+
+再レビューが必要な場合は、対象Pull Requestへ次のコメントを投稿する。
+
+```text
+@codex review
+```
+
+Codexは通常のGitHub Reviewとして結果を投稿する。レビュー時にはリポジトリ内の`AGENTS.md`を参照するため、リポジトリ固有のレビュー観点は同ファイルの`Code Review Rules`に記載する。
+
+## 2. Codexレビューの位置づけ
+
+Codexレビューは、CIや人間による最終判断を置き換えるものではなく、コード上の重大な問題・意図との不一致を早期に検出するための追加レビューとして扱う。
+
+Codexから指摘があった場合は内容を確認し、妥当なら修正する。誤検出または意図した挙動である場合は、必要に応じてPull Request上で理由を明記する。
+
+Codexレビュー自体をmainへのマージ必須status checkにはしない。Codexの応答遅延・外部サービス障害によって既存のCIやリポジトリ運用を停止させないためである。
+
+## 3. 既存CI・main rulesetとの関係
+
+Issue #257対応時点のmain ruleset `main protection` は次の状態である。
+
+- mainへの変更はPull Request経由とする。
+- required status checkは`test`。
+- `test`では`make check`を実行する。
+- Codexレビューはrequired status checkではない。
+- approving reviewの必須数は0。
+- force pushは禁止する。
+
+したがって、Codexレビューが成功していても`test`が失敗しているPull Requestはマージ条件を満たさない。一方、Codexレビューの完了そのものはGitHubのruleset上のマージ条件には含めない。
+
+人間Approveを必須化し、条件を満たしたPull Requestを自動マージする運用はIssue #258で別途扱う。#258の実装後は、同Issueでこの文書のマージ条件に関する記述も現行設定へ合わせて更新する。
+
+## 4. 通常のレビュー手順
+
+1. Pull Requestを作成する。
+2. GitHub Actionsの`test`結果を確認する。
+3. Automatic reviewsが有効であればCodexレビューを確認する。
+4. 修正push後など、明示的な再レビューが必要なら`@codex review`をコメントする。
+5. Codexの指摘と人間の確認結果を踏まえてマージ可否を判断する。
+
+## 5. Codexのレビュー観点
+
+Codexが参照する具体的なレビュー観点は`AGENTS.md`の`## Code Review Rules`を正とする。特に、次を優先する。
+
+- 対象Issueの意図・スコープと実装の不一致
+- 認証・認可、秘密情報、外部HTTP通信に関する問題
+- Scheduler・定期実行・本番deployに影響する回帰
+- DB schemaや既存データへ意図しない影響を与える変更
+- 正常系だけでなく失敗時の挙動に関する重大な欠落
+
+フォーマットや静的解析で機械的に検出できる問題は`make check`を優先し、Codexレビューでは重大な正しさ・安全性の問題を重視する。
+
+## 6. 設定変更時の注意
+
+- Codexレビュー導入のために既存の`test` required checkを外さない。
+- Codexレビューをrequired checkへ追加する場合は、本Issueの範囲では行わず、運用上の必要性を別途判断する。
+- GitHub AppやCodexの権限を変更する場合は、必要最小限の範囲を維持する。
+- CodexのGitHub連携仕様が変わった場合は、OpenAI公式ドキュメントを確認して本書を更新する。


### PR DESCRIPTION
## 概要

Issue #257 に基づき、Codex Code ReviewをこのリポジトリのPull Requestレビューへ導入するためのリポジトリ側運用を整備する。

## 変更内容

- `AGENTS.md`
  - OpenAI公式仕様でCodex Code Reviewが参照する `## Code Review Rules` を追加
  - Issue/仕様との整合、認証・秘密情報・外部HTTP、Scheduler・DB・本番運用を優先するレビュー観点を定義
  - 好みだけの命名変更や、Pint/PHPStan等と重複する軽微な指摘を優先しない方針を明記
  - PRレビュー運用文書への導線を追加
- `docs/pull-request-review.md`
  - Codex settingsでのCode review / Automatic reviewsの位置づけ
  - 明示的な再レビュー方法 `@codex review`
  - 現在のmain rulesetとの関係（required checkは`test`、Codexレビュー自体はrequiredにしない）
  - Issue #258で人間Approve＋auto-mergeを別途扱うことを明記

## GitHub設定について

Issue #257対応時点の `main protection` を確認し、既存のrequired status check `test` やbranch protectionは変更していない。Codexレビューをrequired checkにも追加していない。

OpenAI公式ドキュメントを確認し、Codex Code ReviewはCodex settingsから対象repositoryのCode reviewを有効化し、必要に応じてAutomatic reviewsを有効化する方式、明示的な再レビューはPRコメントの `@codex review` で行う方式であることを確認した。

## 検証

- 変更はMarkdownのみ
- `main...agent/issue-257-codex-review` の差分が `AGENTS.md` と `docs/pull-request-review.md` のみであることを確認済み
- PR上の既存 `test` CI結果を確認する
- 本PRでCodexレビューが実際に実行されることを確認する

Refs #257
